### PR TITLE
rtd config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,31 @@
+
+
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt
+        
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs


### PR DESCRIPTION
This pull request introduces a configuration file for Read the Docs to enable automated documentation builds for the project. The new `.readthedocs.yaml` file specifies the build environment, Python version, Sphinx configuration, and documentation dependencies.

Documentation build setup:

* Added a `.readthedocs.yaml` configuration file to define the documentation build process, including the OS, Python version (`3.13`), and Sphinx settings (`docs/conf.py`).
* Configured installation of documentation dependencies using pip and the `docs` extra requirements group.