### PR TITLE
Change convert_all_to_adu default and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 ![](example.jpg)
 *cabaret* is a Python package to simulate astronomical images using the [GAIA catalog](https://en.wikipedia.org/wiki/Gaia_catalogues) of stars.
 
+Documentation can be found at [cabaret.readthedocs.io](https://cabaret.readthedocs.io/).
+
 ## Installation
 
 You can install *cabaret* in a Python (`>=3.11`) environment with
@@ -47,7 +49,5 @@ from cabaret.plot import plot_image
 plot_image(image)
 plt.show()
 ```
-
-## Documentation
 
 Explore the full documentation, API reference, and advanced usage examples at [cabaret.readthedocs.io](https://cabaret.readthedocs.io/).

--- a/src/cabaret/observatory.py
+++ b/src/cabaret/observatory.py
@@ -191,7 +191,7 @@ class Observatory:
         seed: int | None = None,
         timeout: float | None = None,
         sources: Sources | None = None,
-        convert_all_to_adu: bool = False,
+        convert_all_to_adu: bool = True,
         wcs: WCS | None = None,
         fwhm_multiplier: float = 5.0,
     ) -> numpy.ndarray:
@@ -202,7 +202,7 @@ class Observatory:
         From first to last, the images are:
         1. Base image with bias, dark, and flat applied.
         2. Astronomical image with sources, sky background, and noise.
-        3. Final ADU image with pixel defects applied.
+        3. Final image with pixel defects applied.
 
         Parameters
         ----------


### PR DESCRIPTION
Change the default of `convert_all_to_adu` to True for `Observatory.generate_image_stack` and added a direct link to the documentation at [cabaret.readthedocs.io](https://cabaret.readthedocs.io/) near the top of `README.md` for better visibility.