### PR TITLE
Unified photometric calibration and multi-band querying

### DIFF
--- a/complete_example.ipynb
+++ b/complete_example.ipynb
@@ -157,7 +157,7 @@
     "table = cabaret.GaiaQuery.query(\n",
     "    center=center,\n",
     "    radius=camera.get_fov_radius() * 1.5,\n",
-    "    filter_band=filter_band,\n",
+    "    filter_bands=filter_band,\n",
     "    limit=100000,\n",
     "    # timeout=60,\n",
     ")"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,6 +21,7 @@ citation
 :caption: Tutorials
 
 notebooks/configuring_an_observatory.ipynb
+notebooks/multi_band_query.ipynb
 ```
 
 ```{toctree}

--- a/docs/source/notebooks/multi_band_query.ipynb
+++ b/docs/source/notebooks/multi_band_query.ipynb
@@ -1,0 +1,424 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Multi-band Queries\n",
+    "\n",
+    "**cabaret** can fetch several photometric bands in a single TAP query using\n",
+    "`GaiaQuery.get_flux_table()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "import cabaret\n",
+    "\n",
+    "# center = SkyCoord(ra=10.68458, dec=41.26917, unit=\"deg\")  # M31 field\n",
+    "center = SkyCoord(ra=90.0, dec=28.0, unit=\"deg\")  # Galactic anti-center\n",
+    "\n",
+    "table = cabaret.GaiaQuery.get_flux_table(\n",
+    "    center,\n",
+    "    radius=0.15,\n",
+    "    filter_bands=\"all\",\n",
+    "    timeout=60,\n",
+    "    keep_mag=True,  # keep magnitude column\n",
+    "    allow_nulls=True,\n",
+    ")\n",
+    "\n",
+    "print(table.colnames)\n",
+    "print(f\"{len(table)} sources retrieved\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49b1676b",
+   "metadata": {},
+   "source": [
+    "By setting `filter_bands=\"all\"`, we have performed an automated cross-match between the Gaia DR3 (optical) and 2MASS (near-infrared) catalogs. The resulting table contains 16 columns of astrometric and photometric data, including:\n",
+    "- Gaia Bands: `g_flux`, `bp_flux`, and `rp_flux` (covering roughly 330 to 1050 nm).\n",
+    "- 2MASS Bands: `j_flux`, `h_flux`, and `ks_flux` (covering 1.2 to 2.2 μm)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ff22aee",
+   "metadata": {},
+   "source": [
+    "## Catalog completeness & selection bias"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db18c724",
+   "metadata": {},
+   "source": [
+    "By requiring that every source in this sample has a valid measurement in at least one Gaia and one 2MASS band, we have introduced a **color selection bias**.\n",
+    "\n",
+    "2MASS was a ground-based survey significantly less sensitive than the space-based Gaia mission. To be detected in 2MASS, a star must be either very nearby, intrinsically very bright, or very red. Therefore, we have effectively filtered out faint blue stars (like White Dwarfs) and distant blue giants. Our sample is dominated by M-dwarfs and Red Giants, which emit the vast majority of their light at longer wavelengths."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d909fd8",
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from astroquery.svo_fps import SvoFps\n",
+    "\n",
+    "filters = {\n",
+    "    \"Gaia BP\": (\"GAIA/GAIA3.Gbp\", \"#5E3C99\", \"--\"),\n",
+    "    \"Gaia G\": (\"GAIA/GAIA3.G\", \"#008837\", \"--\"),\n",
+    "    \"Gaia RP\": (\"GAIA/GAIA3.Grp\", \"#D7191C\", \"--\"),\n",
+    "    \"2MASS J\": (\"2MASS/2MASS.J\", \"#FDAE61\", \"-\"),\n",
+    "    \"2MASS H\": (\"2MASS/2MASS.H\", \"#A6611A\", \"-\"),\n",
+    "    \"2MASS Ks\": (\"2MASS/2MASS.Ks\", \"#404040\", \"-\"),\n",
+    "}\n",
+    "\n",
+    "plt.figure(figsize=(9, 4.5), dpi=100)\n",
+    "for label, (filter_id, color, style) in filters.items():\n",
+    "    data = SvoFps.get_transmission_data(filter_id)\n",
+    "    plt.plot(\n",
+    "        data[\"Wavelength\"] / 10,\n",
+    "        data[\"Transmission\"],\n",
+    "        label=label,\n",
+    "        color=color,\n",
+    "        linestyle=style,\n",
+    "        lw=2.5,\n",
+    "    )\n",
+    "\n",
+    "plt.xlabel(r\"Wavelength (nm)\")\n",
+    "plt.ylabel(\"Transmission\")\n",
+    "\n",
+    "plt.legend(ncol=2, loc=\"upper left\")\n",
+    "\n",
+    "plt.xlim(300, 2400)\n",
+    "plt.ylim(0, 1.0)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ebb5cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "complete_table = cabaret.GaiaQuery.get_flux_table(\n",
+    "    center,\n",
+    "    radius=0.15,\n",
+    "    filter_bands=[\"G\", \"BP\", \"RP\"],\n",
+    "    timeout=60,\n",
+    "    allow_nulls=True,\n",
+    "    keep_mag=True,\n",
+    ")\n",
+    "\n",
+    "has_nan = np.any(\n",
+    "    np.isnan(\n",
+    "        np.lib.recfunctions.structured_to_unstructured(\n",
+    "            np.array(\n",
+    "                complete_table[\n",
+    "                    \"phot_g_mean_mag\", \"phot_bp_mean_mag\", \"phot_rp_mean_mag\"\n",
+    "                ]\n",
+    "            )\n",
+    "        )\n",
+    "    ),\n",
+    "    axis=1,\n",
+    ")\n",
+    "\n",
+    "print(\n",
+    "    f\"There are {len(complete_table)} sources for this field in the Gaia catalog, \"\n",
+    "    f\"of which {len(complete_table[~has_nan]) / len(complete_table) * 100:.0f}% have \"\n",
+    "    f\"measurements in all three GAIA bands.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21019304",
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "gaia_cols = {\"RP\": \"phot_rp_mean_mag\", \"G\": \"phot_g_mean_mag\", \"BP\": \"phot_bp_mean_mag\"}\n",
+    "\n",
+    "bins = np.linspace(10, 20, 30)\n",
+    "colors = {\"RP\": \"#fdb462\", \"G\": \"#fb8072\", \"BP\": \"#bc80bd\"}\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4.5))\n",
+    "\n",
+    "# Plot 1: Overall Frequency (Population Density)\n",
+    "for band, col in gaia_cols.items():\n",
+    "    # We plot the 'complete_table' to show the true population before filtering\n",
+    "    ax1.hist(\n",
+    "        complete_table[col],\n",
+    "        bins=bins,\n",
+    "        histtype=\"step\",\n",
+    "        color=colors[band],\n",
+    "        label=band,\n",
+    "        lw=1.5,\n",
+    "    )\n",
+    "\n",
+    "ax1.set_title(\"Population Density (All Gaia Sources)\")\n",
+    "ax1.set_xlabel(\"Gaia Magnitude\")\n",
+    "ax1.set_ylabel(\"Number of Sources\")\n",
+    "ax1.set_yscale(\"log\")  # Vital to see the faint tail\n",
+    "ax1.legend(frameon=False)\n",
+    "\n",
+    "# Plot 2: Crossmatch Efficiency (The Selection Filter)\n",
+    "for band, col in gaia_cols.items():\n",
+    "    total_counts, _ = np.histogram(complete_table[col], bins=bins)\n",
+    "    matched_counts, _ = np.histogram(table[col], bins=bins)\n",
+    "    fraction = (\n",
+    "        np.divide(\n",
+    "            matched_counts,\n",
+    "            total_counts,\n",
+    "            out=np.zeros_like(matched_counts, dtype=float),\n",
+    "            where=total_counts != 0,\n",
+    "        )\n",
+    "        * 100\n",
+    "    )\n",
+    "    ax2.stairs(fraction, bins, color=colors[band], lw=2)\n",
+    "\n",
+    "ax2.set_title(\"2MASS crossmatch completeness (%)\")\n",
+    "ax2.set_xlabel(\"Gaia Magnitude\")\n",
+    "ax2.set_ylabel(\"Success Rate (%)\")\n",
+    "ax2.set_yscale(\"log\")\n",
+    "ax2.set_ylim(0.1, 110)\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "275776bc",
+   "metadata": {},
+   "source": [
+    "- Population Density (Left): This shows the raw number of detections per band. Notice that RP (orange) detects significantly more faint stars than BP (purple). In this field, many stars are simply too red or too faint to be detected by the Blue Spectrometer at all.\n",
+    "- Crossmatch Efficiency (Right): This measures how many Gaia detections have a 2MASS counterpart.\n",
+    "  - The BP band appears to have the highest completeness because it is the most \"exclusive\"—it only detects stars bright enough that they are almost guaranteed to be in 2MASS.\n",
+    "  - The G and RP bands show lower completeness at the faint end because they are sensitive enough to find a \"hidden\" population of stars that are below the detection threshold of 2MASS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "source": [
+    "## Generate one simulated image per band\n",
+    "\n",
+    "We build a `Sources` object for each band from the shared table, then\n",
+    "simulate an exposure. Passing them as an argument bypasses the Gaia query inside `generate_image`, so all three images are based on exactly the same star list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83006dda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observatory = cabaret.Observatory(camera=cabaret.Camera.create_ideal_camera())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sorted from shortest wavelength to longest wavelength\n",
+    "sources_names = {\n",
+    "    f\"Gaia {band}\": f\"{band.lower()}_flux\" for band in [\"BP\", \"G\", \"RP\"]\n",
+    "} | {f\"2MASS {band}\": f\"{band.lower()}_flux\" for band in [\"J\", \"H\", \"KS\"]}\n",
+    "\n",
+    "sources_dict = {\n",
+    "    key: cabaret.Sources.from_arrays(\n",
+    "        ra=table[\"ra\"],\n",
+    "        dec=table[\"dec\"],\n",
+    "        fluxes=table[col],\n",
+    "    )\n",
+    "    for key, col in sources_names.items()\n",
+    "}\n",
+    "\n",
+    "common = dict(ra=center.ra.deg, dec=center.dec.deg, exp_time=30, seed=42)\n",
+    "\n",
+    "images = {}\n",
+    "\n",
+    "for i, (title, src) in enumerate(sources_dict.items()):\n",
+    "    img = observatory.generate_image(**common, sources=src)\n",
+    "    images[title.split(\" \")[-1]] = img.astype(\"float\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bb585b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "bins = np.logspace(np.log10(10), np.log10(1e7), 50)\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "for key, color in zip(\n",
+    "    [\"Gaia BP\", \"Gaia G\", \"Gaia RP\"], [\"#bc80bd\", \"#fb8072\", \"#fdb462\"]\n",
+    "):\n",
+    "    if \"2MASS\" in key:\n",
+    "        continue\n",
+    "    ax.hist(\n",
+    "        sources_dict[key].fluxes,\n",
+    "        bins=bins,\n",
+    "        log=True,\n",
+    "        alpha=0.8,\n",
+    "        label=key,\n",
+    "        histtype=\"step\",\n",
+    "        color=color,\n",
+    "        lw=2,\n",
+    "    )\n",
+    "\n",
+    "ax.set_xscale(\"log\")\n",
+    "ax.set_xlabel(\"Flux (photons/s/m²)\")\n",
+    "ax.set_ylabel(\"Number of sources\")\n",
+    "ax.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3a3d47d",
+   "metadata": {},
+   "source": [
+    "The resulting flux distribution follows a clear spectral logic: $\\mathrm{BP < G < RP}$.\n",
+    "- Red Population Bias: By requiring 2MASS counterparts, we have selected a sample dominated by cooler stars (Red Giants and M-dwarfs). These stars naturally peak in the RP band.\n",
+    "\n",
+    "- The G-Band \"Dilution\": While the G-band filter is broad, its sensitivity extends into blue wavelengths where our red-biased sample has little to no emission. This makes the G-band total count lower than the RP band, which is more perfectly aligned with the stars' output.\n",
+    "\n",
+    "- Survivor Bias: The BP band shows the lowest flux simply because it is the most distant from the peak emission of our target stars."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11b6a466",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from cabaret.plot import plot_image\n",
+    "\n",
+    "fig, axes = plt.subplots(2, 3, figsize=(15, 10))\n",
+    "\n",
+    "for i, (title, src) in enumerate(sources_dict.items()):\n",
+    "    # plot_image handles the \"look\" of the data automatically\n",
+    "    ax = axes.flatten()[i]\n",
+    "    plot_image(images[title.split(\" \")[-1]], title=title, ax=ax, add_colorbar=False)\n",
+    "    if i not in [3, 4, 5]:\n",
+    "        ax.set_xlabel(\"\")\n",
+    "    if i not in [0, 3, 6]:\n",
+    "        ax.set_ylabel(\"\")\n",
+    "\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02497cc1",
+   "metadata": {},
+   "source": [
+    "By comparing these panels, we see that some stars appear significantly brighter in some bands than others. This is a direct visual confirmation of the spectral differences in our sample."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "source": [
+    "## Multi-wavelength synthesis (RGB)\n",
+    "\n",
+    "To visualize the full spectral range of our data, we can combine three independent bands into a single false-color composite. We map these bands to the RGB channels in chromatic order—assigning the shortest wavelength to blue and the longest to red:\n",
+    "\n",
+    "We map the three bands to colour channels in wavelength order:\n",
+    "- G (optical) → Blue\n",
+    "- H (near-IR) → Green\n",
+    "- KS (near-IR) → Red\n",
+    "\n",
+    "In this scheme, blue objects generally represent hotter stars, while deep red objects highlight the coolest M-dwarfs or stars obscured by interstellar dust."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef25a9cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.visualization import ManualInterval, make_rgb\n",
+    "\n",
+    "maximum = 0.0\n",
+    "for img in images.values():\n",
+    "    val = np.percentile(img, 99.5)\n",
+    "    if val > maximum:\n",
+    "        maximum = val\n",
+    "rgb = make_rgb(\n",
+    "    image_r=images[\"KS\"],  # ~2150 nm, near-IR\n",
+    "    image_g=images[\"H\"],  # ~1650 nm, near-IR\n",
+    "    image_b=images[\"G\"],  # ~673 nm, optical\n",
+    "    interval=ManualInterval(vmin=0, vmax=maximum),\n",
+    ")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "ax.set_xlabel(\"Pixels\")\n",
+    "ax.set_ylabel(\"Pixels\")\n",
+    "_ = ax.imshow(rgb, origin=\"lower\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "cabaret"
 readme = "README.md"
 repository = "https://github.com/ppp-one/cabaret"
 requires-python = ">=3.11"
-version = "0.4.7"
+version = "0.4.8"
 
 [project.optional-dependencies]
 plot = ["matplotlib"]

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -322,6 +322,7 @@ def add_stars(
     fwhm_multiplier: float = 5.0,
 ) -> np.ndarray:
     """Add stars to the image using the Moffat profile and sky background."""
+    sources = sources.drop_nan_fluxes()
     if len(sources) > 0:
         fluxes = (
             sources.fluxes

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -677,7 +677,8 @@ class GaiaQuery:
             filter_bands = [filter_bands]
         if not isinstance(filter_bands, Sequence):
             raise ValueError(
-                f"filter_bands must be a Filters, str, or sequence thereof, got {type(filter_bands)}"
+                f"filter_bands must be a Filters, str, or sequence thereof, "
+                f"got {type(filter_bands)}"
             )
         if not filter_bands:
             raise ValueError("At least one filter_band must be specified.")

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -25,27 +25,27 @@ class Filters(Enum):
     --------
     >>> from cabaret.queries import Filters
     >>> Filters.G
-    <Filters.G: 'phot_g_mean_flux'>
+    <Filters.G: 'phot_g_mean_mag'>
     >>> Filters.from_string('RP')
-    <Filters.RP: 'phot_rp_mean_flux'>
+    <Filters.RP: 'phot_rp_mean_mag'>
     >>> Filters.is_tmass('J')
     True
     >>> Filters.options()
     ('G', 'BP', 'RP', 'J', 'H', 'KS')
     """
 
-    G = "phot_g_mean_flux"
-    """ Gaia G band flux in [e-/s] """
-    BP = "phot_bp_mean_flux"
-    """ Gaia BP band flux in [e-/s] """
-    RP = "phot_rp_mean_flux"
-    """ Gaia RP band flux in [e-/s] """
+    G = "phot_g_mean_mag"
+    """Gaia G band magnitude [Gaia Vega system]"""
+    BP = "phot_bp_mean_mag"
+    """Gaia BP band magnitude [Gaia Vega system]"""
+    RP = "phot_rp_mean_mag"
+    """Gaia RP band magnitude [Gaia Vega system]"""
     J = "j_m"
-    """ 2MASS J band magnitude """
+    """2MASS J-band magnitude [2MASS Vega system]"""
     H = "h_m"
-    """ 2MASS H band magnitude """
+    """2MASS H-band magnitude [2MASS Vega system]"""
     KS = "ks_m"
-    """ 2MASS KS band magnitude """
+    """2MASS KS-band magnitude [2MASS Vega system]"""
 
     @classmethod
     def options(cls) -> tuple[str, ...]:
@@ -67,13 +67,14 @@ class Filters(Enum):
     def is_tmass(cls, value: "Filters | str") -> bool:
         """Check if the filter_band string is a 2MASS filter_band."""
         if isinstance(value, cls):
-            return value.name in ("J", "H", "KS")
+            name = value.name
         elif isinstance(value, str):
-            return value.upper() in ("J", "H", "KS")
+            name = value.upper()
         else:
             raise ValueError(
-                f"Value must be an Filters enum or string, got {type(value)}"
+                f"Value must be a Filters enum or string, got {type(value)}"
             )
+        return name in ("J", "H", "KS")
 
     @classmethod
     def ensure_enum(cls, value: "Filters | str") -> "Filters":
@@ -86,6 +87,11 @@ class Filters(Enum):
             raise ValueError(
                 f"Value must be a Filters enum or string, got {type(value)}"
             )
+
+    @classmethod
+    def all(cls) -> list["Filters"]:
+        """Return all filter bands in definition order."""
+        return list(cls)
 
     @classmethod
     def is_valid(cls, value: str) -> bool:
@@ -138,9 +144,9 @@ _TAP_CONFIG: dict[GaiaTAPSource, dict] = {
         "dec": "gaia.dec",
         "pmra": "gaia.pmra",
         "pmdec": "gaia.pmdec",
-        "g_flux": "phot_g_mean_flux",
-        "bp_flux": "phot_bp_mean_flux",
-        "rp_flux": "phot_rp_mean_flux",
+        "g_mag": "phot_g_mean_mag",
+        "bp_mag": "phot_bp_mean_mag",
+        "rp_mag": "phot_rp_mean_mag",
         "tmass_joins": [
             "INNER JOIN gaiadr3.tmass_psc_xsc_best_neighbour AS tmass_match"
             " ON tmass_match.source_id = gaia.source_id",
@@ -157,9 +163,9 @@ _TAP_CONFIG: dict[GaiaTAPSource, dict] = {
         "dec": "g.DE_ICRS",
         "pmra": "g.pmRA",
         "pmdec": "g.pmDE",
-        "g_flux": "g.FG",
-        "bp_flux": "g.FBP",
-        "rp_flux": "g.FRP",
+        "g_mag": "g.Gmag",
+        "bp_mag": "g.BPmag",
+        "rp_mag": "g.RPmag",
         "tmass_joins": [
             'INNER JOIN "II/246/out" AS t ON g."2MASS" = t."2MASS"',
         ],
@@ -211,6 +217,7 @@ class GaiaQuery:
         limit: int = 100000,
         timeout: float | None = None,
         tap_source: GaiaTAPSource | str | None = None,
+        allow_nulls: bool = False,
     ) -> Table:
         """Query a Gaia DR3 TAP service within a given radius around the center.
 
@@ -225,11 +232,11 @@ class GaiaQuery:
         filter_bands : Filters, str, or sequence thereof, optional
             One or more filter bands to include as flux columns. Accepts a single
             ``Filters`` member or its name as a string, or a list of either.
+            Pass ``"all"`` to request every available band (``Filters.all()``).
             Default is ``Filters.G``. When multiple bands are requested, the
-            ``ORDER BY`` is determined by the first band (brightest-first
-            convention: DESC for Gaia fluxes, ASC for 2MASS magnitudes).
+            ``ORDER BY`` is determined by the first band (brightest-first,
+            ASC for all magnitude columns).
             If any 2MASS band is included the 2MASS cross-match join is added.
-            All requested bands must be non-NULL for a row to be returned.
         limit : int, optional
             The maximum number of sources to retrieve from the Gaia archive.
             By default, it is set to 100000.
@@ -240,6 +247,10 @@ class GaiaQuery:
             TAP service to query. Accepts a ``GaiaTAPSource`` member or its name
             as a string (e.g. ``"GAIA"`` or ``"VIZIER"``). If None, uses
             ``GaiaQuery.DEFAULT_TAP_SOURCE`` (default: ``GaiaTAPSource.VIZIER``).
+        allow_nulls : bool, optional
+            If False (default), only rows where all requested band columns are
+            non-NULL are returned (``IS NOT NULL`` filter per band). Set to True
+            to allow rows with missing magnitude values through.
 
         Returns
         -------
@@ -247,7 +258,7 @@ class GaiaQuery:
             The raw Astropy Table returned by the TAP service, with columns
             normalised to ``ra``, ``dec``, ``pmra``, ``pmdec``, and one flux
             column per requested band named after ``filter_band.value``
-            (e.g. ``phot_g_mean_flux``, ``h_m``).
+            (e.g. ``phot_g_mean_mag``, ``h_m``).
 
         Examples
         --------
@@ -289,20 +300,17 @@ class GaiaQuery:
                 col_expr = cfg[_TMASS_COL_KEY[band.name]]
                 need_tmass_join = True
             else:
-                col_expr = cfg[band.name.lower() + "_flux"]
+                col_expr = cfg[band.name.lower() + "_mag"]
             select_cols.append(f"{col_expr} AS {band.value}")
-            where.append(f"{col_expr} IS NOT NULL")
+            if not allow_nulls:
+                where.append(f"{col_expr} IS NOT NULL")
 
         if need_tmass_join:
             joins.extend(cfg["tmass_joins"])
 
-        # ORDER BY first band, brightest-first convention.
+        # ORDER BY first band, brightest-first: ASC for all magnitude columns.
         first = bands[0]
-        order_by = (
-            f"{first.value} ASC"
-            if Filters.is_tmass(first.name)
-            else f"{first.value} DESC"
-        )
+        order_by = f"{first.value} ASC"
 
         radius = radius.value if isinstance(radius, Quantity) else float(radius)
         where.append(
@@ -337,18 +345,20 @@ class GaiaQuery:
         limit: int = 100000,
         timeout: float | None = None,
         tap_source: GaiaTAPSource | str | None = None,
+        allow_nulls: bool = False,
+        keep_mag: bool = False,
     ) -> Table:
         """Query and return a Table with all columns expressed as physical fluxes.
 
         Identical to :meth:`query` but additionally:
 
         * applies proper-motion correction when ``dateobs`` is given, and
-        * converts any 2MASS magnitude columns to photons/s using
+        * converts any 2MASS magnitude columns to photons/s/m² using
           :meth:`_tmass_mag_to_photons` and renames them (e.g. ``"j_m"`` →
-          ``"j_flux"``).
-
-        Gaia flux columns (G, BP, RP) are already in e-/s and are returned
-        unchanged, keeping their original names (e.g. ``"phot_g_mean_flux"``).
+          ``"j_flux"``), and
+        * converts Gaia magnitude columns to photons/s/m² using
+          :meth:`_gaia_mag_to_photons` and renames them (e.g.
+          ``"phot_g_mean_mag"`` → ``"g_flux"``).
 
         Parameters
         ----------
@@ -366,14 +376,24 @@ class GaiaQuery:
             Query timeout in seconds. Default is None (no timeout).
         tap_source : GaiaTAPSource, str, or None, optional
             TAP service to query. Default is ``GaiaQuery.DEFAULT_TAP_SOURCE``.
+        allow_nulls : bool, optional
+            Forwarded to :meth:`query`. If True, rows with NULL magnitude values
+            are included in the result. Default is False.
+        keep_mag : bool, optional
+            If True, retain the original magnitude column (e.g.
+            ``"phot_g_mean_mag"``) alongside the converted flux column
+            (e.g. ``"g_flux"``). Default is False.
 
         Returns
         -------
         astropy.table.Table
             Table with columns ``ra``, ``dec``, ``pmra``, ``pmdec``, and one
-            flux column per requested band. Gaia band columns keep their TAP
-            names (e.g. ``"phot_g_mean_flux"``); 2MASS band columns are renamed
+            flux column per requested band, all in photons/s/m². Gaia band
+            columns are renamed from ``"phot_<b>_mean_mag"`` to
+            ``"<b>_flux"`` (e.g. ``"g_flux"``); 2MASS band columns are renamed
             from ``"<band>_m"`` to ``"<band>_flux"`` (e.g. ``"h_flux"``).
+            When ``keep_mag=True``, the original magnitude columns are also
+            present.
 
         Examples
         --------
@@ -394,6 +414,7 @@ class GaiaQuery:
             limit=limit,
             timeout=timeout,
             tap_source=tap_source,
+            allow_nulls=allow_nulls,
         )
 
         if dateobs is not None:
@@ -401,17 +422,20 @@ class GaiaQuery:
 
         seen: set[Filters] = set()
         for band in bands:
-            if band in seen or not Filters.is_tmass(band.name):
-                seen.add(band)
+            if band in seen:
                 continue
             seen.add(band)
             col = band.value
-            new_name = str(col).removesuffix("_m") + "_flux"
-            table[new_name] = GaiaQuery._tmass_mag_to_photons(
+            if Filters.is_tmass(band.name):
+                new_name = str(col).removesuffix("_m") + "_flux"
+            else:
+                new_name = band.name.lower() + "_flux"  # e.g. "g_flux", "bp_flux"
+            table[new_name] = GaiaQuery._mag_to_photons(
                 table[col].value.data,  # type: ignore
                 band,
             )
-            table.remove_column(col)
+            if not keep_mag:
+                table.remove_column(col)
 
         return table
 
@@ -462,8 +486,7 @@ class GaiaQuery:
 
         Notes
         -----
-        If `filter_band` is a 2MASS filter (J, H, KS), the fluxes are calculated
-        from the 2MASS magnitudes using `cabaret.queries.tmass_mag_to_photons`.
+        Fluxes are always returned in photons/s/m² via :meth:`_mag_to_photons`.
 
         Raises
         ------
@@ -476,17 +499,8 @@ class GaiaQuery:
         >>> from astropy.coordinates import SkyCoord
         >>> center = SkyCoord(ra=10.68458, dec=41.26917, unit='deg')
         >>> sources = GaiaQuery.get_sources(
-        ...     center, radius=0.1, timeout=30
+        ...     center, radius=0.1, timeout=30, limit=10
         ... )  # doctest: +SKIP
-        Sources(coords=<SkyCoord (ICRS): (ra, dec) in deg
-            [(10.63950247, 41.26393165), (10.6880729 , 41.22524785),
-            (10.70349581, 41.25357386), (10.70022208, 41.26019689),
-            (10.71333998, 41.29943347), (10.73974676, 41.2942209 ),
-            (10.71181048, 41.29130279), (10.68780207, 41.31717482),
-            (10.63804045, 41.27468757), (10.64397532, 41.25237352)]>, fluxes=array(
-                [169435.62814443,  52203.9396396 ,  41716.18126449,  29035.89106422,
-                22990.85994301,  17672.53437883,  15953.21022642,  15077.12262318,
-                14004.42013396,  12271.11779953]))
 
         """
         filter_band = Filters.ensure_enum(filter_band)
@@ -503,13 +517,10 @@ class GaiaQuery:
         if dateobs is not None:
             table = GaiaQuery._apply_proper_motion(table, dateobs)
 
-        if Filters.is_tmass(filter_band.name):
-            fluxes = GaiaQuery._tmass_mag_to_photons(
-                table[filter_band.value].value.data,  # type: ignore
-                filter_band,
-            )
-        else:
-            fluxes = table[filter_band.value].value.data  # type: ignore
+        fluxes = GaiaQuery._mag_to_photons(
+            table[filter_band.value].value.data,  # type: ignore
+            filter_band,
+        )
         table.remove_rows(np.isnan(fluxes))
         fluxes = fluxes[~np.isnan(fluxes)]
 
@@ -583,29 +594,46 @@ class GaiaQuery:
             raise exc[0]
         return result[0]
 
+    # Vega zero-points for all supported bands.
+    # See _derive_band_properties for how these were obtained.
+    _BAND_PROPS = {
+        "G": {"dlam_lam": 0.7117, "flux_m0_Jy": 4031.5},
+        "BP": {"dlam_lam": 0.5131, "flux_m0_Jy": 3683.21},
+        "RP": {"dlam_lam": 0.3741, "flux_m0_Jy": 5040.41},
+        "J": {"dlam_lam": 0.1312, "flux_m0_Jy": 1594.0},
+        "H": {"dlam_lam": 0.151, "flux_m0_Jy": 1024.0},
+        "KS": {"dlam_lam": 0.1214, "flux_m0_Jy": 666.8},
+    }
+
     @staticmethod
-    def _tmass_mag_to_photons(mags: np.ndarray, filter_band: Filters) -> np.ndarray:
-        """Convert 2MASS J magnitudes to photon fluxes at mag 0.
+    def _mag_to_photons(mags: np.ndarray, filter_band: Filters) -> np.ndarray:
+        """Convert Vega magnitudes to photon flux in photons/s/m².
 
-        Reference: https://lweb.cfa.harvard.edu/~dfabricant/huchra/ay145/mags.html
-        Returns photons/sec/m^2 for each magnitude.
+        Applies to all supported bands (Gaia G/BP/RP and 2MASS J/H/KS).
+        Formula: Δλ/λ × F₀ × 1.51×10⁷ × 10^(−0.4 × mag),
+        where F₀ is the Vega zero-point flux density in Jy.
+
+        Parameters
+        ----------
+        mags : np.ndarray
+            Vega magnitudes.
+        filter_band : Filters
+            Any supported filter band.
+
+        Returns
+        -------
+        np.ndarray
+            Flux in photons/s/m².
         """
-        # Use a dict for 2MASS filter properties
-        dlam_lam_map = {"J": 0.16, "H": 0.23, "KS": 0.23}
-        flux_m0_map = {"J": 1600, "H": 1080, "KS": 670}
-
         try:
-            dlam_lam = dlam_lam_map[filter_band.name]
-            flux_m0 = flux_m0_map[filter_band.name]
+            props = GaiaQuery._BAND_PROPS[filter_band.name]
         except KeyError:
             raise ValueError(
-                f"tmass_mag_to_photons expects a 2MASS filter (J,H,KS), "
-                f"got {filter_band}."
+                f"_mag_to_photons: unsupported filter {filter_band}. "
+                f"Supported: {list(GaiaQuery._BAND_PROPS)}."
             )
-
-        Jy = 1.51e7  # [photons sec^-1 m^-2 (dlambda/lambda)^-1]
-        photons = dlam_lam * flux_m0 * Jy  # [photons sec^-1 m^-2] at mag 0
-        return photons * 10 ** (-0.4 * mags)
+        Jy = 1.51e7  # [photons s^-1 m^-2 (Δλ/λ)^-1]
+        return props["dlam_lam"] * props["flux_m0_Jy"] * Jy * 10 ** (-0.4 * mags)
 
     # Gaia DR3 reference epoch J2016.0 expressed as a decimal year.
     _GAIA_DR3_EPOCH = float(Time(2016.0, format="jyear").decimalyear)
@@ -625,8 +653,15 @@ class GaiaQuery:
             )
 
         years = float(dateobs.decimalyear) - GaiaQuery._GAIA_DR3_EPOCH
-        table["ra"] += years * table["pmra"] / 1000 / 3600  # type: ignore
-        table["dec"] += years * table["pmdec"] / 1000 / 3600  # type: ignore
+        # Zero-fill missing proper motions so sources without pm data keep their
+        # catalogue position rather than being silently NaN-corrupted.
+        # np.where returns a plain ndarray (no units/mask), so use column
+        # assignment (=) rather than in-place (+=) to avoid Astropy dropping
+        # column metadata when mixing Column and ndarray operands.
+        pmra = np.where(np.isnan(table["pmra"]), 0.0, table["pmra"])
+        pmdec = np.where(np.isnan(table["pmdec"]), 0.0, table["pmdec"])
+        table["ra"] = table["ra"] + years * pmra / 1000 / 3600  # type: ignore
+        table["dec"] = table["dec"] + years * pmdec / 1000 / 3600  # type: ignore
 
         return table
 
@@ -634,7 +669,83 @@ class GaiaQuery:
     def _normalize_bands(
         filter_bands: "Filters | str | Sequence[Filters | str]",
     ) -> list["Filters"]:
-        """Normalize filter_bands argument to a list[Filters]."""
+        """Normalize filter_bands argument to a list[Filters].
+
+        Passing the string ``"all"`` (case-insensitive) expands to every
+        available filter, equivalent to ``Filters.all()``.
+        """
+        if isinstance(filter_bands, str) and filter_bands.upper() == "ALL":
+            return Filters.all()
         if isinstance(filter_bands, Filters | str):
             filter_bands = [filter_bands]
         return [Filters.ensure_enum(b) for b in filter_bands]
+
+    @staticmethod
+    def _derive_band_properties():
+        """
+        Derives physical band properties for Gaia DR3 and 2MASS.
+
+        This method serves as a reference for how the Vega zero-point fluxes and Δλ/λ
+        values were obtained for the supported bands.
+
+        Sources
+        -------
+
+        2MASS: Derived from Isophotal Fluxes
+        Cohen et al. 2003 AJ 126 1090 (Table 2) | Bibcode: 2003AJ....126.1090C
+        https://doi.org/10.1086/376474
+
+        Gaia: Derived from Magnitude Zero Points
+        Riello et al. 2021 A&A 649 A3 (Table 3) | Bibcode: 2021A&A...649A...3R
+        https://doi.org/10.1051/0004-6361/202039587
+
+        Example
+        -------
+        >>> from cabaret.queries import GaiaQuery
+        >>> properties = GaiaQuery._derive_band_properties()
+        >>> properties == GaiaQuery._BAND_PROPS
+        True
+        """
+        AB_ZERO_POINT_JY = 3631.0
+
+        # GAIA DR3 (Riello et al. 2021 A&A 649 A3, Table 3)
+        # Format: {Band: [ZP_VEG, ZP_AB, FWHM_nm, LAM_0_nm]}
+        gaia_table = {
+            "G": [25.6874, 25.8010, 454.82, 639.07],
+            "BP": [25.3385, 25.3540, 265.90, 518.26],
+            "RP": [24.7479, 25.1040, 292.75, 782.51],
+        }
+
+        # 2MASS (Martin Cohen et al. 2003 AJ 126 1090, Table 2)
+        # Format: {Band: [Flux_Jy, Bandwidth_um, Lam_Iso_um]}
+        # Note: KS refers to the 2MASS "Short" K-band, which has a narrower
+        # bandwidth and shorter pivot wavelength than standard Johnson K.
+        tmass_table = {
+            "J": [1594.0, 0.162, 1.235],
+            "H": [1024.0, 0.251, 1.662],
+            "KS": [666.8, 0.262, 2.159],
+        }
+
+        results = {}
+
+        for band, (zp_v, zp_a, fwhm, l0) in gaia_table.items():
+            # dlam_lam = FWHM / Pivot Wavelength
+            dlam_lam = fwhm / l0
+            # Flux density of Vega = 3631 * 10^(0.4 * (ZP_AB - ZP_VEG))
+            flux_jy = AB_ZERO_POINT_JY * (10 ** (0.4 * (zp_a - zp_v)))
+
+            results[band] = {
+                "dlam_lam": round(dlam_lam, 4),
+                "flux_m0_Jy": round(flux_jy, 2),
+            }
+
+        for band, (flux_jy, width, l_iso) in tmass_table.items():
+            # dlam_lam = Width / Isophotal Wavelength
+            dlam_lam = width / l_iso
+
+            results[band] = {
+                "dlam_lam": round(dlam_lam, 4),
+                "flux_m0_Jy": round(flux_jy, 2),
+            }
+
+        return results

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -213,7 +213,7 @@ class GaiaQuery:
     def query(
         center: tuple[float, float] | SkyCoord,
         radius: float | Angle,
-        filter_bands: "Filters | str | Sequence[Filters | str]" = Filters.G,
+        filter_bands: Filters | str | Sequence[Filters | str] = Filters.G,
         limit: int = 100000,
         timeout: float | None = None,
         tap_source: GaiaTAPSource | str | None = None,
@@ -230,7 +230,7 @@ class GaiaQuery:
             The radius of the FOV in degrees. If a Quantity is given, it must be
             convertible to degrees.
         filter_bands : Filters, str, or sequence thereof, optional
-            One or more filter bands to include as flux columns. Accepts a single
+            One or more filter bands to include as magnitude columns. Accepts a single
             ``Filters`` member or its name as a string, or a list of either.
             Pass ``"all"`` to request every available band (``Filters.all()``).
             Default is ``Filters.G``. When multiple bands are requested, the
@@ -256,7 +256,7 @@ class GaiaQuery:
         -------
         astropy.table.Table
             The raw Astropy Table returned by the TAP service, with columns
-            normalised to ``ra``, ``dec``, ``pmra``, ``pmdec``, and one flux
+            normalised to ``ra``, ``dec``, ``pmra``, ``pmdec``, and one magnitude
             column per requested band named after ``filter_band.value``
             (e.g. ``phot_g_mean_mag``, ``h_m``).
 
@@ -340,7 +340,7 @@ class GaiaQuery:
     def get_flux_table(
         center: tuple[float, float] | SkyCoord,
         radius: float | Angle,
-        filter_bands: "Filters | str | Sequence[Filters | str]" = Filters.G,
+        filter_bands: Filters | str | Sequence[Filters | str] = Filters.G,
         dateobs: datetime | None = None,
         limit: int = 100000,
         timeout: float | None = None,
@@ -353,12 +353,9 @@ class GaiaQuery:
         Identical to :meth:`query` but additionally:
 
         * applies proper-motion correction when ``dateobs`` is given, and
-        * converts any 2MASS magnitude columns to photons/s/m² using
-          :meth:`_tmass_mag_to_photons` and renames them (e.g. ``"j_m"`` →
-          ``"j_flux"``), and
-        * converts Gaia magnitude columns to photons/s/m² using
-          :meth:`_gaia_mag_to_photons` and renames them (e.g.
-          ``"phot_g_mean_mag"`` → ``"g_flux"``).
+        * converts supported magnitude columns to photons/s/m² using
+          :meth:`_mag_to_photons` and renames them (e.g. ``"j_m"`` →
+          ``"j_flux"`` and ``"phot_g_mean_mag"`` → ``"g_flux"``).
 
         Parameters
         ----------
@@ -431,7 +428,7 @@ class GaiaQuery:
             else:
                 new_name = band.name.lower() + "_flux"  # e.g. "g_flux", "bp_flux"
             table[new_name] = GaiaQuery._mag_to_photons(
-                table[col].value.data,  # type: ignore
+                np.ma.filled(table[col].value, np.nan),  # type: ignore
                 band,
             )
             if not keep_mag:
@@ -518,7 +515,7 @@ class GaiaQuery:
             table = GaiaQuery._apply_proper_motion(table, dateobs)
 
         fluxes = GaiaQuery._mag_to_photons(
-            table[filter_band.value].value.data,  # type: ignore
+            np.ma.filled(table[filter_band.value].value, np.nan),  # type: ignore
             filter_band,
         )
         table.remove_rows(np.isnan(fluxes))
@@ -667,7 +664,7 @@ class GaiaQuery:
 
     @staticmethod
     def _normalize_bands(
-        filter_bands: "Filters | str | Sequence[Filters | str]",
+        filter_bands: Filters | str | Sequence[Filters | str],
     ) -> list["Filters"]:
         """Normalize filter_bands argument to a list[Filters].
 
@@ -678,6 +675,12 @@ class GaiaQuery:
             return Filters.all()
         if isinstance(filter_bands, Filters | str):
             filter_bands = [filter_bands]
+        if not isinstance(filter_bands, Sequence):
+            raise ValueError(
+                f"filter_bands must be a Filters, str, or sequence thereof, got {type(filter_bands)}"
+            )
+        if not filter_bands:
+            raise ValueError("At least one filter_band must be specified.")
         return [Filters.ensure_enum(b) for b in filter_bands]
 
     @staticmethod

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -1,4 +1,5 @@
 import threading
+from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
 
@@ -176,8 +177,8 @@ class GaiaQuery:
     """Class to query Gaia DR3 data and retrieve sources.
 
     The class provides methods to query a configurable TAP service and return
-    either the raw Astropy Table or a Sources instance with RA-DEC coordinates
-    and fluxes.
+    either the raw Astropy Table, a flux-normalised multi-band Table, or a
+    Sources instance with RA-DEC coordinates and fluxes.
 
     The TAP service is selected via ``GaiaQuery.DEFAULT_TAP_SOURCE`` (class
     level) or the per-call ``tap_source`` argument.  The default is
@@ -206,7 +207,7 @@ class GaiaQuery:
     def query(
         center: tuple[float, float] | SkyCoord,
         radius: float | Angle,
-        filter_band: Filters = Filters.G,
+        filter_bands: "Filters | str | Sequence[Filters | str]" = Filters.G,
         limit: int = 100000,
         timeout: float | None = None,
         tap_source: GaiaTAPSource | str | None = None,
@@ -221,8 +222,14 @@ class GaiaQuery:
         radius : float or astropy.units.Quantity
             The radius of the FOV in degrees. If a Quantity is given, it must be
             convertible to degrees.
-        filter_band : Filters or str, optional
-            The filter to use for the flux column. Default is Filters.G.
+        filter_bands : Filters, str, or sequence thereof, optional
+            One or more filter bands to include as flux columns. Accepts a single
+            ``Filters`` member or its name as a string, or a list of either.
+            Default is ``Filters.G``. When multiple bands are requested, the
+            ``ORDER BY`` is determined by the first band (brightest-first
+            convention: DESC for Gaia fluxes, ASC for 2MASS magnitudes).
+            If any 2MASS band is included the 2MASS cross-match join is added.
+            All requested bands must be non-NULL for a row to be returned.
         limit : int, optional
             The maximum number of sources to retrieve from the Gaia archive.
             By default, it is set to 100000.
@@ -238,11 +245,12 @@ class GaiaQuery:
         -------
         astropy.table.Table
             The raw Astropy Table returned by the TAP service, with columns
-            normalised to ``ra``, ``dec``, ``pmra``, ``pmdec``, and the flux
-            column named after the filter (e.g. ``phot_g_mean_flux``).
+            normalised to ``ra``, ``dec``, ``pmra``, ``pmdec``, and one flux
+            column per requested band named after ``filter_band.value``
+            (e.g. ``phot_g_mean_flux``, ``h_m``).
 
-        Example
-        -------
+        Examples
+        --------
         >>> from cabaret.queries import GaiaQuery
         >>> from astropy.coordinates import SkyCoord
         >>> center = SkyCoord(ra=10.68458, dec=41.26917, unit='deg')
@@ -252,7 +260,7 @@ class GaiaQuery:
             tap_source = GaiaQuery.DEFAULT_TAP_SOURCE
         tap_source = GaiaTAPSource.ensure_enum(tap_source)
 
-        filter_band = Filters.ensure_enum(filter_band)
+        bands = GaiaQuery._normalize_bands(filter_bands)
 
         if isinstance(center, SkyCoord):
             ra = center.ra.deg  # type: ignore
@@ -262,37 +270,39 @@ class GaiaQuery:
 
         cfg = _TAP_CONFIG[tap_source]
 
-        # Flux column expression (source-dependent) aliased to the standard name.
-        if Filters.is_tmass(filter_band.name):
-            gaia_flux_expr = cfg["g_flux"]
-            gaia_flux_alias = Filters.G.value
-            tmass_col_expr = cfg[_TMASS_COL_KEY[filter_band.name]]
-            tmass_col_alias = filter_band.value
-        else:
-            flux_key = filter_band.name.lower() + "_flux"  # g_flux, bp_flux, rp_flux
-            gaia_flux_expr = cfg[flux_key]
-            gaia_flux_alias = filter_band.value
-            tmass_col_expr = None
-            tmass_col_alias = None
-
         select_cols = [
             f"{cfg['ra']} AS ra",
             f"{cfg['dec']} AS dec",
             f"{cfg['pmra']} AS pmra",
             f"{cfg['pmdec']} AS pmdec",
-            f"{gaia_flux_expr} AS {gaia_flux_alias}",
         ]
-        joins = []
-        where = []
+        where: list[str] = []
+        joins: list[str] = []
+        need_tmass_join = False
+        seen: set[Filters] = set()
 
-        if Filters.is_tmass(filter_band.name):
-            select_cols.append(f"{tmass_col_expr} AS {tmass_col_alias}")
+        for band in bands:
+            if band in seen:
+                continue
+            seen.add(band)
+            if Filters.is_tmass(band.name):
+                col_expr = cfg[_TMASS_COL_KEY[band.name]]
+                need_tmass_join = True
+            else:
+                col_expr = cfg[band.name.lower() + "_flux"]
+            select_cols.append(f"{col_expr} AS {band.value}")
+            where.append(f"{col_expr} IS NOT NULL")
+
+        if need_tmass_join:
             joins.extend(cfg["tmass_joins"])
-            order_by = f"{tmass_col_alias} ASC"
-            where.append(f"{tmass_col_expr} IS NOT NULL")
-        else:
-            order_by = f"{gaia_flux_alias} DESC"
-            where.append(f"{gaia_flux_expr} IS NOT NULL")
+
+        # ORDER BY first band, brightest-first convention.
+        first = bands[0]
+        order_by = (
+            f"{first.value} ASC"
+            if Filters.is_tmass(first.name)
+            else f"{first.value} DESC"
+        )
 
         radius = radius.value if isinstance(radius, Quantity) else float(radius)
         where.append(
@@ -305,7 +315,7 @@ class GaiaQuery:
         joins_clause = "\n".join(joins)
         where_clause = " AND ".join(where)
 
-        query = f"""
+        adql = f"""
         SELECT TOP {limit} {select_clause}
         FROM {cfg["from"]}
         {joins_clause}
@@ -314,8 +324,95 @@ class GaiaQuery:
         """
 
         table = GaiaQuery._launch_job_with_timeout(
-            query, tap_source=tap_source, timeout=timeout
+            adql, tap_source=tap_source, timeout=timeout
         )
+        return table
+
+    @staticmethod
+    def get_flux_table(
+        center: tuple[float, float] | SkyCoord,
+        radius: float | Angle,
+        filter_bands: "Filters | str | Sequence[Filters | str]" = Filters.G,
+        dateobs: datetime | None = None,
+        limit: int = 100000,
+        timeout: float | None = None,
+        tap_source: GaiaTAPSource | str | None = None,
+    ) -> Table:
+        """Query and return a Table with all columns expressed as physical fluxes.
+
+        Identical to :meth:`query` but additionally:
+
+        * applies proper-motion correction when ``dateobs`` is given, and
+        * converts any 2MASS magnitude columns to photons/s using
+          :meth:`_tmass_mag_to_photons` and renames them (e.g. ``"j_m"`` →
+          ``"j_flux"``).
+
+        Gaia flux columns (G, BP, RP) are already in e-/s and are returned
+        unchanged, keeping their original names (e.g. ``"phot_g_mean_flux"``).
+
+        Parameters
+        ----------
+        center : tuple or astropy.coordinates.SkyCoord
+            The sky coordinates of the center of the FOV.
+        radius : float or astropy.units.Quantity
+            The radius of the FOV in degrees.
+        filter_bands : Filters, str, or sequence thereof, optional
+            One or more filter bands. Default is ``Filters.G``.
+        dateobs : datetime.datetime or None, optional
+            Observation date for proper-motion correction. Default is None.
+        limit : int, optional
+            Maximum number of sources to retrieve. Default is 100000.
+        timeout : float or None, optional
+            Query timeout in seconds. Default is None (no timeout).
+        tap_source : GaiaTAPSource, str, or None, optional
+            TAP service to query. Default is ``GaiaQuery.DEFAULT_TAP_SOURCE``.
+
+        Returns
+        -------
+        astropy.table.Table
+            Table with columns ``ra``, ``dec``, ``pmra``, ``pmdec``, and one
+            flux column per requested band. Gaia band columns keep their TAP
+            names (e.g. ``"phot_g_mean_flux"``); 2MASS band columns are renamed
+            from ``"<band>_m"`` to ``"<band>_flux"`` (e.g. ``"h_flux"``).
+
+        Examples
+        --------
+        >>> from cabaret.queries import GaiaQuery, Filters
+        >>> from astropy.coordinates import SkyCoord
+        >>> center = SkyCoord(ra=10.68458, dec=41.26917, unit='deg')
+        >>> table = GaiaQuery.get_flux_table(
+        ...     center, radius=0.1, filter_bands=[Filters.G, Filters.H, Filters.KS],
+        ...     limit=10, timeout=30,
+        ... )  # doctest: +SKIP
+        """
+        bands = GaiaQuery._normalize_bands(filter_bands)
+
+        table = GaiaQuery.query(
+            center=center,
+            radius=radius,
+            filter_bands=bands,
+            limit=limit,
+            timeout=timeout,
+            tap_source=tap_source,
+        )
+
+        if dateobs is not None:
+            table = GaiaQuery._apply_proper_motion(table, dateobs)
+
+        seen: set[Filters] = set()
+        for band in bands:
+            if band in seen or not Filters.is_tmass(band.name):
+                seen.add(band)
+                continue
+            seen.add(band)
+            col = band.value
+            new_name = str(col).removesuffix("_m") + "_flux"
+            table[new_name] = GaiaQuery._tmass_mag_to_photons(
+                table[col].value.data,  # type: ignore
+                band,
+            )
+            table.remove_column(col)
+
         return table
 
     @staticmethod
@@ -399,7 +496,7 @@ class GaiaQuery:
             radius=radius,
             limit=limit,
             timeout=timeout,
-            filter_band=filter_band,
+            filter_bands=filter_band,
             tap_source=tap_source,
         )
 
@@ -532,3 +629,12 @@ class GaiaQuery:
         table["dec"] += years * table["pmdec"] / 1000 / 3600  # type: ignore
 
         return table
+
+    @staticmethod
+    def _normalize_bands(
+        filter_bands: "Filters | str | Sequence[Filters | str]",
+    ) -> list["Filters"]:
+        """Normalize filter_bands argument to a list[Filters]."""
+        if isinstance(filter_bands, Filters | str):
+            filter_bands = [filter_bands]
+        return [Filters.ensure_enum(b) for b in filter_bands]

--- a/src/cabaret/sources.py
+++ b/src/cabaret/sources.py
@@ -29,7 +29,8 @@ class Sources:
     coords: SkyCoord
     """SkyCoords instance with the RA and DEC coordinates of the sources."""
     fluxes: np.ndarray
-    """An array of shape (n,) containing the fluxes of the sources."""
+    """An array of shape (n,) containing the fluxes of the sources in units of
+    photons/s/m²."""
 
     def __post_init__(self):
         if not isinstance(self.coords, SkyCoord):
@@ -114,6 +115,7 @@ class Sources:
             An array of shape (n,) containing the DEC coordinates of the sources in deg.
         fluxes : np.ndarray
             An array of shape (n,) containing the fluxes of the sources.
+            These should be of units photons/s/m².
         **kwargs
             Additional keyword arguments passed to the Sources constructor.
 
@@ -140,6 +142,21 @@ class Sources:
             "fluxes": fluxes,
         }
         return cls(**(parameters))
+
+    def drop_nan_fluxes(self) -> "Sources":
+        """Return a new Sources instance with any sources that have NaN fluxes removed.
+
+        If no sources have NaN fluxes, returns self.
+
+        Returns
+        -------
+        Sources
+            A Sources instance with NaN flux entries removed.
+        """
+        mask = np.isnan(self.fluxes)
+        if mask.any():
+            return self[~mask]
+        return self
 
     @classmethod
     def get_test_sources(cls) -> "Sources":

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -3,6 +3,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 
 from cabaret.queries import Filters, GaiaQuery, GaiaTAPSource
+from cabaret.sources import Sources
 
 from .utils import has_tap_source
 
@@ -50,11 +51,11 @@ def test_get_sources_timeout():
 
 
 @skip_no_vizier
-def test_query_single_band_backward_compat():
+def test_query_single_band():
     """query() still accepts a single band as a string."""
     center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
     table = GaiaQuery.query(center, radius=0.05, filter_bands="G", limit=5, timeout=30)
-    assert "phot_g_mean_flux" in table.colnames
+    assert "phot_g_mean_mag" in table.colnames
     assert len(table) <= 5
 
 
@@ -71,7 +72,7 @@ def test_query_multi_band_tmass():
     )
     assert "h_m" in table.colnames
     assert "ks_m" in table.colnames
-    assert "phot_g_mean_flux" not in table.colnames
+    assert "phot_g_mean_mag" not in table.colnames
     assert len(table) <= 10
     # Ordered by H ASC (smallest magnitude = brightest first)
     assert table["h_m"][0] <= table["h_m"][-1]
@@ -94,3 +95,102 @@ def test_get_flux_table_multi_band():
     assert np.all(table["h_flux"] > 0)
     assert np.all(table["ks_flux"] > 0)
     assert np.median(table["h_flux"]) > 1000
+
+
+@skip_no_vizier
+def test_get_flux_table_gaia_bands():
+    """get_flux_table() converts Gaia mags to positive photon fluxes."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    table = GaiaQuery.get_flux_table(
+        center,
+        radius=0.05,
+        filter_bands=[Filters.G, Filters.BP, Filters.RP],
+        limit=10,
+        timeout=30,
+    )
+    assert "g_flux" in table.colnames
+    assert "bp_flux" in table.colnames
+    assert "rp_flux" in table.colnames
+    assert "phot_g_mean_mag" not in table.colnames
+    assert np.all(table["g_flux"] > 0)
+    assert np.median(table["g_flux"]) > 1000
+
+
+@skip_no_vizier
+def test_get_flux_table_keep_mag():
+    """keep_mag=True retains magnitude columns alongside flux columns."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    table = GaiaQuery.get_flux_table(
+        center,
+        radius=0.05,
+        filter_bands=[Filters.G, Filters.H],
+        limit=10,
+        timeout=30,
+        keep_mag=True,
+    )
+    assert "g_flux" in table.colnames
+    assert "h_flux" in table.colnames
+    assert "phot_g_mean_mag" in table.colnames
+    assert "h_m" in table.colnames
+
+
+@skip_no_vizier
+def test_get_flux_table_allow_nulls():
+    """allow_nulls=True lets rows with missing band values through."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    # Query Gaia-only: without allow_nulls the result has no NaNs
+    strict = GaiaQuery.get_flux_table(
+        center,
+        radius=0.05,
+        filter_bands="G",
+        limit=50,
+        timeout=30,
+        allow_nulls=False,
+    )
+    lenient = GaiaQuery.get_flux_table(
+        center,
+        radius=0.05,
+        filter_bands="G",
+        limit=50,
+        timeout=30,
+        allow_nulls=True,
+    )
+    # Allowing nulls should return at least as many rows
+    assert len(lenient) >= len(strict)
+
+
+@skip_no_vizier
+def test_get_flux_table_filter_bands_all():
+    """filter_bands='all' returns flux columns for every supported band."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    table = GaiaQuery.get_flux_table(
+        center,
+        radius=0.05,
+        filter_bands="all",
+        limit=10,
+        timeout=30,
+    )
+    for col in ("g_flux", "bp_flux", "rp_flux", "j_flux", "h_flux", "ks_flux"):
+        assert col in table.colnames
+
+
+def test_drop_nan_fluxes_removes_nans():
+    """drop_nan_fluxes() removes sources with NaN flux values."""
+    sources = Sources.from_arrays(
+        ra=np.array([1.0, 2.0, 3.0]),
+        dec=np.array([0.0, 0.0, 0.0]),
+        fluxes=np.array([100.0, np.nan, 200.0]),
+    )
+    clean = sources.drop_nan_fluxes()
+    assert len(clean) == 2
+    assert not np.any(np.isnan(clean.fluxes))
+
+
+def test_drop_nan_fluxes_no_nans_returns_self():
+    """drop_nan_fluxes() returns self when no NaNs are present."""
+    sources = Sources.from_arrays(
+        ra=np.array([1.0, 2.0]),
+        dec=np.array([0.0, 0.0]),
+        fluxes=np.array([100.0, 200.0]),
+    )
+    assert sources.drop_nan_fluxes() is sources

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,7 +1,8 @@
+import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 
-from cabaret.queries import GaiaQuery, GaiaTAPSource
+from cabaret.queries import Filters, GaiaQuery, GaiaTAPSource
 
 from .utils import has_tap_source
 
@@ -46,3 +47,50 @@ def test_get_sources_timeout():
     center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
     with pytest.raises(TimeoutError):
         GaiaQuery.get_sources(center, radius=0.05, limit=10, timeout=0.0001)
+
+
+@skip_no_vizier
+def test_query_single_band_backward_compat():
+    """query() still accepts a single band as a string."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    table = GaiaQuery.query(center, radius=0.05, filter_bands="G", limit=5, timeout=30)
+    assert "phot_g_mean_flux" in table.colnames
+    assert len(table) <= 5
+
+
+@skip_no_vizier
+def test_query_multi_band_tmass():
+    """query() with two 2MASS bands returns both columns, no spurious Gaia flux."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    table = GaiaQuery.query(
+        center,
+        radius=0.05,
+        filter_bands=[Filters.H, Filters.KS],
+        limit=10,
+        timeout=30,
+    )
+    assert "h_m" in table.colnames
+    assert "ks_m" in table.colnames
+    assert "phot_g_mean_flux" not in table.colnames
+    assert len(table) <= 10
+    # Ordered by H ASC (smallest magnitude = brightest first)
+    assert table["h_m"][0] <= table["h_m"][-1]
+
+
+@skip_no_vizier
+def test_get_flux_table_multi_band():
+    """get_flux_table() converts 2MASS mags to positive photon fluxes."""
+    center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
+    table = GaiaQuery.get_flux_table(
+        center,
+        radius=0.05,
+        filter_bands=[Filters.H, Filters.KS],
+        limit=10,
+        timeout=30,
+    )
+    assert "h_flux" in table.colnames
+    assert "ks_flux" in table.colnames
+    # Values should be positive photon fluxes, not raw magnitudes (~10–15)
+    assert np.all(table["h_flux"] > 0)
+    assert np.all(table["ks_flux"] > 0)
+    assert np.median(table["h_flux"]) > 1000

--- a/uv.lock
+++ b/uv.lock
@@ -61,11 +61,11 @@ wheels = [
 
 [[package]]
 name = "astropy-iers-data"
-version = "0.2026.4.13.0.58.2"
+version = "0.2026.4.20.0.58.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/4a/5ebf17e2a2bf82747641c66babce54295239f10b315bdb36d076429fd048/astropy_iers_data-0.2026.4.13.0.58.2.tar.gz", hash = "sha256:a079f31cd3e235afd9b9d435be53fc69ae619aef93339c54863767c3c76e4807", size = 1930728, upload-time = "2026-04-13T00:58:40.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/24/7f977f00017c6f4c200585f3333cdfa7d018bfc236851d8885a08aae09ac/astropy_iers_data-0.2026.4.20.0.58.15.tar.gz", hash = "sha256:f54c3ecf435c8d7fe627dee7e75c5bc390beac3f3350b36b04730b54df72ccf1", size = 1931255, upload-time = "2026-04-20T00:58:59.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/c7/da797a2ae6a64c27553871ff2c3bf64343970efce730b3247e6bd2c00994/astropy_iers_data-0.2026.4.13.0.58.2-py3-none-any.whl", hash = "sha256:f93d788bda4b0b20dfc7672719699178c106ddd15e2048069a6f74ee7cf2a7ef", size = 1987515, upload-time = "2026-04-13T00:58:38.753Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/fe/6dc92a96bed2703e86dba2d46d4a66ebb1f275054dcce4c6299e0ef9b492/astropy_iers_data-0.2026.4.20.0.58.15-py3-none-any.whl", hash = "sha256:37e9c1c32215584067a55839b8ce744cf0b3b0a30b7ebebc2d1e908b0556a24d", size = 1988029, upload-time = "2026-04-20T00:58:57.323Z" },
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "cabaret"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
@@ -639,11 +639,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.28.0"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -757,11 +757,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.18"
+version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -2153,27 +2153,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.10"
+version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
-    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
-    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
-    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
-    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Gaia G/BP/RP columns were previously queried as e-/s (instrument-level electron counts), while they were treated as physical fluxes with photons/s/m². All six bands (Gaia + 2MASS) now query Vega magnitudes and convert to photons/s/m² using a single `_mag_to_photons` method with literature zero-points (Riello et al. 2021 for Gaia, Cohen et al. 2003 for 2MASS).
- `get_flux_table()` gains `allow_nulls` and `keep_mag` parameters, and `filter_bands="all"` now expands to all supported bands.
- `Sources.drop_nan_fluxes()` is added and called in `add_stars()` to safely handle nulls introduced by `allow_nulls=True`.
- NaN-corrupted coordinates in `_apply_proper_motion` are fixed for sources without proper motion data.
- A multi-band tutorial notebook is added to the docs.

## Changes

**`src/cabaret/queries.py`**
- Replace `phot_*_mean_flux` TAP columns with `phot_*_mean_mag` for Gaia G, BP, RP
- Rename `_tmass_mag_to_photons` → `_mag_to_photons`; now handles all six bands via `_BAND_PROPS` dict
- Add `allow_nulls: bool` to `query()` and `get_flux_table()`
- Add `keep_mag: bool` to `get_flux_table()`
- Add `filter_bands="all"` shorthand via `_normalize_bands()`
- Add `Filters.all()` class method
- Fix `_apply_proper_motion` to zero-fill missing pm values instead of propagating NaN into coordinates
- Add `_derive_band_properties()` as a reproducible reference for zero-point derivation

**`src/cabaret/sources.py`**
- Add `Sources.drop_nan_fluxes()` method

**`src/cabaret/image.py`**
- Call `sources.drop_nan_fluxes()` at the top of `add_stars()`

**`tests/test_queries.py`**
- Update column name assertions from `phot_g_mean_flux` → `phot_g_mean_mag`
- Add tests for Gaia flux conversion, `allow_nulls`, `keep_mag`, `filter_bands="all"`, and `Sources.drop_nan_fluxes()`

**`docs/`**
- Add `multi_band_query.ipynb` tutorial notebook covering cross-matched Gaia+2MASS queries, catalog completeness/selection bias, per-band image simulation, and RGB composite synthesis
- Register notebook in `index.md`

## Test

- [x] Run `pytest tests/test_queries.py` with network access — all TAP tests pass
- [x] `test_drop_nan_fluxes_removes_nans` and `test_drop_nan_fluxes_no_nans_returns_self` pass without network
- [x] Execute `multi_band_query.ipynb` end-to-end and verify plots render correctly
- [x] `get_flux_table(..., filter_bands="all", keep_mag=True)` returns both flux and magnitude columns for all six bands