### PR TITLE
Add offline SQLite catalog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ center = SkyCoord(ra=323.362583, dec=-0.82325, unit="deg")
 table = cabaret.GaiaQuery.query(
     center=center,
     radius=camera.get_fov_radius() * 1.5,
-    filter_band=cabaret.Filters.G,
+    filter_bands=cabaret.Filters.G,
 )
 
 # Filter out bright sources
@@ -133,6 +133,31 @@ image = observatory.generate_image(
     dec=center.dec.deg,
     exp_time=0.5,
     sources=sources,
+)
+```
+
+### Offline SQLite Catalogs
+
+You can query a local SQLite catalog instead of a remote TAP endpoint.
+
+The local table is expected to contain at least `ra` and `dec`, and optionally
+`pmra`, `pmdec`, plus Gaia/2MASS magnitude columns like `phot_g_mean_mag`,
+`phot_bp_mean_mag`, `phot_rp_mean_mag`, `j_m`, `h_m`, `ks_m`.
+
+```python
+import cabaret
+from astropy.coordinates import SkyCoord
+
+sqlite_source = cabaret.GaiaSQLiteSource(
+    database="/data/catalogs/gaia_subset.sqlite",
+)
+
+table = cabaret.GaiaQuery.query(
+    center=SkyCoord(ra=323.362583, dec=-0.82325, unit="deg"),
+    radius=0.1,
+    filter_bands=[cabaret.Filters.G],
+    tap_source=sqlite_source,
+    limit=5000,
 )
 ```
 

--- a/docs/source/cabaret.md
+++ b/docs/source/cabaret.md
@@ -1,7 +1,8 @@
 # API
 
 ## The Observatory
-The `Observatory` class is the main entry point for simulating astronomical images. 
+
+The `Observatory` class is the main entry point for simulating astronomical images.
 
 ```{eval-rst}
 .. autosummary::
@@ -12,6 +13,7 @@ The `Observatory` class is the main entry point for simulating astronomical imag
 ```
 
 ### The Observatory Devices
+
 The `Observatory` class encapsulates the configuration of all key devices at an observatory, as well as its site.
 
 ```{eval-rst}
@@ -32,7 +34,7 @@ A notable feature of the Camera class is its support for pixel defects, which ar
 The simulation of images uses two important concepts:
 
 - **Filters**: Photometric bands (e.g., G, R, I) that determine the wavelength range in which the catalog fluxes are extracted for the simulation.
-- **GaiaQuery**: Provides methods to query star catalogs such as Gaia and 2MASS, returning tables or ready-to-use Sources objects for simulations. The TAP service endpoint can be selected via `GaiaTAPSource` (or by passing ``"GAIA"`` / ``"VIZIER"`` as a string).
+- **GaiaQuery**: Provides methods to query star catalogs such as Gaia and 2MASS, returning tables or ready-to-use Sources objects for simulations. Query backends can be selected via `GaiaTAPSource` (or by passing ``"GAIA"`` / ``"VIZIER"`` as a string) or via `GaiaSQLiteSource` / ``sqlite:///...`` for offline catalogs.
 - **Sources**: Representations of stars with positions and fluxes, either queried from catalogs or provided directly.
 
 ```{eval-rst}
@@ -42,6 +44,7 @@ The simulation of images uses two important concepts:
 
    cabaret.Filters
    cabaret.GaiaQuery
+   cabaret.GaiaSQLiteSource
    cabaret.GaiaTAPSource
    cabaret.Sources
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,7 +13,7 @@ It allows you to generate synthetic images, configure observatory components, an
 installation
 motivation
 notebooks/quickstart.ipynb
-local_database
+local_catalog
 citation
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,6 +13,7 @@ It allows you to generate synthetic images, configure observatory components, an
 installation
 motivation
 notebooks/quickstart.ipynb
+local_database
 citation
 ```
 

--- a/docs/source/local_catalog.md
+++ b/docs/source/local_catalog.md
@@ -1,8 +1,8 @@
-# Local database
+# Local catalog
 
 `GaiaQuery` supports querying offline SQLite catalogs in addition to online
-TAP services. You can select sources either by a circular region
-(`center` + `radius`) or by rectangular `bounds` `(ra_min, ra_max, dec_min, dec_max)`.
+TAP services. While TAP services offer access to the full Gaia archive, local SQLite catalogs provide significantly lower latency and faster query execution,
+making them ideal for large-scale simulations or working without an internet connection.
 
 ## Using a local SQLite catalog
 
@@ -24,7 +24,7 @@ center = SkyCoord(ra=323.36, dec=-0.82, unit="deg")
 table = cabaret.GaiaQuery.query(
     center=center,
     radius=0.1,  # degrees
-    filter_bands=[cabaret.Filters.G, cabaret.Filters.H],
+    filter_bands=[cabaret.Filters.G, cabaret.Filters.J],
     tap_source=sqlite_source,  # or "sqlite:///path/to/file.sqlite"
 )
 ```
@@ -32,44 +32,6 @@ table = cabaret.GaiaQuery.query(
 You may pass the `tap_source` as either a `GaiaSQLiteSource` instance or a
 string. Accepted string forms include a full SQLite URI (`sqlite:///...`) or a
 plain path ending in `.db`, `.sqlite` or `.sqlite3`.
-
-## Sharded (declination-ring) catalogs
-
-Some offline catalogs are split into declination "rings" (shards) named like
-`-25_-24`, `-24_-23`, etc. If the configured `table` name is not present in
-the database, Cabaret will auto-detect these ring tables and only query the
-shards that overlap your requested declination range. This keeps queries fast
-when only a small declination slice is required.
-
-Example using a sharded SQLite file (RA wraparound shown below):
-
-```python
-import cabaret
-
-table = cabaret.GaiaQuery.query(
-    bounds=(359.5, 0.5, -2.0, 2.0),  # ra_min, ra_max wrap across 0 deg
-    filter_bands="G",
-    tap_source="sqlite:///data/catalogs/gaia_tmass_sharded.sqlite",
-)
-```
-
-## RA wraparound (bounds that cross RA=0)
-
-RA values are interpreted modulo 360. If `ra_min <= ra_max` the interval is
-treated as contiguous; if `ra_min > ra_max` the interval is interpreted as
-wrapping across RA=0 (for example `(350.0, 10.0, -5.0, 5.0)`). Both the
-TAP and SQLite query code handle wraparound automatically, selecting rows
-whose RA falls into the wrapped interval.
-
-## Notes and tips
-
-- Use `filter_bands` to request one or more bands (e.g. `Filters.G` or
-  `['G','H']`). Including a 2MASS band (J/H/KS) will add the required
-  cross-match columns when available.
-- If your SQLite table contains many rows, prefer a rectangular pre-filter
-  (`bounds`) or a small `limit` to keep memory and runtime reasonable.
-- Cabaret will only query the shard tables that intersect the requested
-  declination range; you don't need to list shard names manually.
 
 ### Changing the default TAP source
 
@@ -84,13 +46,49 @@ cabaret.GaiaQuery.DEFAULT_TAP_SOURCE = cabaret.GaiaSQLiteSource(
     table="table_name",
 )
 
-# Subsequent calls that omit `tap_source` will use the SQLite file.
+# Subsequent calls will use the SQLite database by default
 image = cabaret.Observatory().generate_image(
     ra=12.33230,  # right ascension in degrees
     dec=30.4343,  # declination in degrees
     exp_time=10,  # exposure time in seconds
 )
 ```
+
+## Sharded (declination-ring) catalogs
+
+Some offline catalogs are split into declination "rings" (shards) named like
+`-90_-89`, `-89_-88`, etc. If the configured `table` name is not present in
+the database, Cabaret will auto-detect these ring tables and only query the
+shards that overlap your requested declination range. This keeps queries fast
+when only a small declination slice is required.
+
+Prebuilt sharded SQLite databases of the Gaia-2MASS crossmatch catalogs containing G and J magnitudes used at the SPECULOOS observatory can be downloaded here: [Gaia-2MASS Local Sharded SQLite Catalogue](https://zenodo.org/records/18214672). In the example below, we download the `gaia_tmass_7_jm_cut.db` catalog (~11 MB) and query a region across `RA=0`.
+
+```python
+import requests
+
+import cabaret
+
+url = "https://zenodo.org/records/18214672/files/gaia_tmass_7_jm_cut.db"
+local_path = "gaia_tmass_7_jm_cut.db"
+
+with open(local_path, "wb") as f:
+    f.write(requests.get(url).content)
+
+table = cabaret.GaiaQuery.query(
+    bounds=(359.5, 0.5, -1.0, 1.0),  # ra_min, ra_max wrap across 0 deg
+    filter_bands=["G", "J"],
+    tap_source=local_path,
+)
+```
+
+## RA wraparound (bounds that cross RA=0)
+
+RA values are interpreted modulo 360. If `ra_min <= ra_max` the interval is
+treated as contiguous; if `ra_min > ra_max` the interval is interpreted as
+wrapping across RA=0 (for example `(350.0, 10.0, -5.0, 5.0)`). Both the
+TAP and SQLite query code handle wraparound automatically, selecting rows
+whose RA falls into the wrapped interval.
 
 ## See also
 

--- a/docs/source/local_catalog.md
+++ b/docs/source/local_catalog.md
@@ -82,7 +82,7 @@ table = cabaret.GaiaQuery.query(
 )
 ```
 
-## RA wraparound (bounds that cross RA=0)
+## RA wraparound
 
 RA values are interpreted modulo 360. If `ra_min <= ra_max` the interval is
 treated as contiguous; if `ra_min > ra_max` the interval is interpreted as
@@ -92,5 +92,5 @@ whose RA falls into the wrapped interval.
 
 ## See also
 
-- The `GaiaQuery` implementation: [src/cabaret/queries.py](src/cabaret/queries.py)
+- {doc}`GaiaQuery API Reference <generated/cabaret.GaiaQuery>`
 - Prebuilt sharded Gaia+2MASS SQLite catalogs: [ppp-one/gaia-tmass-sqlite](https://github.com/ppp-one/gaia-tmass-sqlite)

--- a/docs/source/local_database.md
+++ b/docs/source/local_database.md
@@ -1,0 +1,77 @@
+# Local database
+
+`GaiaQuery` supports querying offline SQLite catalogs in addition to online
+TAP services. You can select sources either by a circular region
+(`center` + `radius`) or by rectangular `bounds` `(ra_min, ra_max, dec_min, dec_max)`.
+
+## Using a local SQLite catalog
+
+Create a `GaiaSQLiteSource` to point Cabaret at a local SQLite file and
+optional table name. The table is expected to expose Gaia-like columns named
+similarly to the TAP service (for example: `ra`, `dec`, `phot_g_mean_mag`,
+`h_m`, ...). Example:
+
+```python
+import cabaret
+from astropy.coordinates import SkyCoord
+
+sqlite_source = cabaret.GaiaSQLiteSource(
+    database="/data/catalogs/gaia_subset.sqlite",
+    table="gaia_sources",
+)
+
+center = SkyCoord(ra=323.36, dec=-0.82, unit="deg")
+table = cabaret.GaiaQuery.query(
+    center=center,
+    radius=0.1,  # degrees
+    filter_bands=[cabaret.Filters.G, cabaret.Filters.H],
+    tap_source=sqlite_source,  # or "sqlite:///path/to/file.sqlite"
+)
+```
+
+You may pass the `tap_source` as either a `GaiaSQLiteSource` instance or a
+string. Accepted string forms include a full SQLite URI (`sqlite:///...`) or a
+plain path ending in `.db`, `.sqlite` or `.sqlite3`.
+
+## Sharded (declination-ring) catalogs
+
+Some offline catalogs are split into declination "rings" (shards) named like
+`-25_-24`, `-24_-23`, etc. If the configured `table` name is not present in
+the database, Cabaret will auto-detect these ring tables and only query the
+shards that overlap your requested declination range. This keeps queries fast
+when only a small declination slice is required.
+
+Example using a sharded SQLite file (RA wraparound shown below):
+
+```python
+import cabaret
+
+table = cabaret.GaiaQuery.query(
+    bounds=(359.5, 0.5, -2.0, 2.0),  # ra_min, ra_max wrap across 0 deg
+    filter_bands="G",
+    tap_source="sqlite:///data/catalogs/gaia_tmass_sharded.sqlite",
+)
+```
+
+## RA wraparound (bounds that cross RA=0)
+
+RA values are interpreted modulo 360. If `ra_min <= ra_max` the interval is
+treated as contiguous; if `ra_min > ra_max` the interval is interpreted as
+wrapping across RA=0 (for example `(350.0, 10.0, -5.0, 5.0)`). Both the
+TAP and SQLite query code handle wraparound automatically, selecting rows
+whose RA falls into the wrapped interval.
+
+## Notes and tips
+
+- Use `filter_bands` to request one or more bands (e.g. `Filters.G` or
+  `['G','H']`). Including a 2MASS band (J/H/KS) will add the required
+  cross-match columns when available.
+- If your SQLite table contains many rows, prefer a rectangular pre-filter
+  (`bounds`) or a small `limit` to keep memory and runtime reasonable.
+- Cabaret will only query the shard tables that intersect the requested
+  declination range; you don't need to list shard names manually.
+
+## See also
+
+- The `GaiaQuery` implementation: [src/cabaret/queries.py](src/cabaret/queries.py)
+- Prebuilt sharded Gaia+2MASS SQLite catalogs: [ppp-one/gaia-tmass-sqlite](https://github.com/ppp-one/gaia-tmass-sqlite)

--- a/docs/source/local_database.md
+++ b/docs/source/local_database.md
@@ -71,6 +71,27 @@ whose RA falls into the wrapped interval.
 - Cabaret will only query the shard tables that intersect the requested
   declination range; you don't need to list shard names manually.
 
+### Changing the default TAP source
+
+You can change the module-wide default TAP source so that calls which omit
+`tap_source` use your local SQLite file by default. For example:
+
+```python
+import cabaret
+
+cabaret.GaiaQuery.DEFAULT_TAP_SOURCE = cabaret.GaiaSQLiteSource(
+    database="/data/catalogs/gaia_subset.sqlite",
+    table="table_name",
+)
+
+# Subsequent calls that omit `tap_source` will use the SQLite file.
+image = cabaret.Observatory().generate_image(
+    ra=12.33230,  # right ascension in degrees
+    dec=30.4343,  # declination in degrees
+    exp_time=10,  # exposure time in seconds
+)
+```
+
 ## See also
 
 - The `GaiaQuery` implementation: [src/cabaret/queries.py](src/cabaret/queries.py)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "cabaret"
 readme = "README.md"
 repository = "https://github.com/ppp-one/cabaret"
 requires-python = ">=3.11"
-version = "0.4.8"
+version = "0.5.0"
 
 [project.optional-dependencies]
 plot = ["matplotlib"]

--- a/src/cabaret/__init__.py
+++ b/src/cabaret/__init__.py
@@ -4,7 +4,7 @@ from cabaret.camera import Camera
 from cabaret.focuser import Focuser
 from cabaret.image import generate_image
 from cabaret.observatory import Observatory
-from cabaret.queries import Filters, GaiaQuery, GaiaTAPSource
+from cabaret.queries import Filters, GaiaQuery, GaiaSQLiteSource, GaiaTAPSource
 from cabaret.site import Site
 from cabaret.sources import Sources
 from cabaret.telescope import Telescope
@@ -14,6 +14,7 @@ __all__ = [
     "Filters",
     "Focuser",
     "GaiaTAPSource",
+    "GaiaSQLiteSource",
     "generate_image",
     "Observatory",
     "Site",

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -192,14 +192,15 @@ def generate_star_image(
 
 
 def get_sources(
-    center: SkyCoord,
-    radius: Angle,
+    center: SkyCoord | None,
+    radius: Angle | None,
     dateobs: datetime,
     n_star_limit: int,
     filter_band: Filters | str,
     timeout: float | None,
     sources: Sources | None = None,
     tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+    bounds: tuple[float, float, float, float] | None = None,
 ) -> Sources:
     """Get sources from Gaia or use provided sources."""
     if not isinstance(sources, Sources):
@@ -207,6 +208,7 @@ def get_sources(
         sources = GaiaQuery.get_sources(
             center=center,
             radius=radius,
+            bounds=bounds,
             dateobs=dateobs,
             limit=n_star_limit,
             filter_band=filter_band,

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -10,7 +10,7 @@ from astropy.wcs import WCS
 
 from cabaret.camera import Camera
 from cabaret.focuser import Focuser
-from cabaret.queries import Filters, GaiaQuery, GaiaTAPSource
+from cabaret.queries import Filters, GaiaQuery, GaiaSQLiteSource, GaiaTAPSource
 from cabaret.site import Site
 from cabaret.sources import Sources
 from cabaret.telescope import Telescope
@@ -199,7 +199,7 @@ def get_sources(
     filter_band: Filters | str,
     timeout: float | None,
     sources: Sources | None = None,
-    tap_source: GaiaTAPSource | str | None = None,
+    tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
 ) -> Sources:
     """Get sources from Gaia or use provided sources."""
     if not isinstance(sources, Sources):
@@ -412,7 +412,7 @@ def add_stars_and_sky(
     sources: Sources | None,
     wcs: WCS | None,
     fwhm_multiplier: float = 5.0,
-    tap_source: GaiaTAPSource | str | None = None,
+    tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
 ) -> np.ndarray:
     """Add stars and sky background to the base image."""
     if light == 1:
@@ -481,7 +481,7 @@ def generate_image(
     sources: Sources | None = None,
     wcs: WCS | None = None,
     fwhm_multiplier: float = 5.0,
-    tap_source: GaiaTAPSource | str | None = None,
+    tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
 ) -> np.ndarray:
     """
     Generate a simulated astronomical image.
@@ -592,7 +592,7 @@ def generate_image_stack(
     convert_all_to_adu: bool = False,
     wcs: WCS | None = None,
     fwhm_multiplier: float = 5.0,
-    tap_source: GaiaTAPSource | str | None = None,
+    tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
 ) -> np.ndarray:
     """
     Generate a stack of images from different stages in the image simulation pipeline.

--- a/src/cabaret/observatory.py
+++ b/src/cabaret/observatory.py
@@ -13,7 +13,7 @@ from cabaret.camera import Camera
 from cabaret.fits_manager import FITSManager
 from cabaret.focuser import Focuser
 from cabaret.image import generate_image, generate_image_stack
-from cabaret.queries import Filters, GaiaTAPSource
+from cabaret.queries import Filters, GaiaSQLiteSource, GaiaTAPSource
 from cabaret.site import Site
 from cabaret.sources import Sources
 from cabaret.telescope import Telescope
@@ -125,7 +125,7 @@ class Observatory:
         sources: Sources | None = None,
         wcs: WCS | None = None,
         fwhm_multiplier: float = 5.0,
-        tap_source: GaiaTAPSource | str | None = None,
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
     ) -> numpy.ndarray:
         """Generate a simulated image of the sky.
 
@@ -202,7 +202,7 @@ class Observatory:
         convert_all_to_adu: bool = True,
         wcs: WCS | None = None,
         fwhm_multiplier: float = 5.0,
-        tap_source: GaiaTAPSource | str | None = None,
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
     ) -> numpy.ndarray:
         """
         Generate a stack of images from different stages in the image simulation

--- a/src/cabaret/observatory.py
+++ b/src/cabaret/observatory.py
@@ -306,7 +306,7 @@ class Observatory:
         fwhm_multiplier: float = 5.0,
         user_header: dict[str, Any] | fits.Header | None = None,
         overwrite: bool = True,
-        tap_source: GaiaTAPSource | str | None = None,
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
     ) -> fits.HDUList:
         """Generate a simulated FITS image of the sky.
 

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -2,6 +2,7 @@ import math
 import re
 import sqlite3
 import threading
+import warnings
 from collections.abc import Callable, Sequence
 from contextlib import closing
 from dataclasses import dataclass
@@ -246,6 +247,7 @@ class GaiaQuery:
         timeout: float | None = None,
         tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
         allow_nulls: bool = False,
+        filter_band: Filters | str | None = None,
     ) -> Table:
         """Query a Gaia DR3 TAP service within a given radius around the center.
 
@@ -288,6 +290,8 @@ class GaiaQuery:
             If False (default), only rows where all requested band columns are
             non-NULL are returned (``IS NOT NULL`` filter per band). Set to True
             to allow rows with missing magnitude values through.
+        filter_band : Filters or str, optional
+            Deprecated. Use ``filter_bands`` instead.
 
         Returns
         -------
@@ -304,6 +308,13 @@ class GaiaQuery:
         >>> center = SkyCoord(ra=10.68458, dec=41.26917, unit='deg')
         >>> table = GaiaQuery.query(center, radius=0.1, limit=10, timeout=30)
         """
+        if filter_band is not None:
+            warnings.warn(
+                "filter_band is deprecated; use filter_bands instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            filter_bands = filter_band
         requested_all = isinstance(filter_bands, str) and filter_bands.upper() == "ALL"
         bands = GaiaQuery._normalize_bands(filter_bands)
         center_coords, radius_deg, bounds_tuple = GaiaQuery._normalize_region(

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -1,4 +1,5 @@
 import math
+import re
 import sqlite3
 import threading
 from collections.abc import Callable, Sequence
@@ -254,6 +255,13 @@ class GaiaQuery:
         radius : float or astropy.units.Quantity
             The radius of the FOV in degrees. If a Quantity is given, it must be
             convertible to degrees.
+        bounds : tuple or None
+            Field-of-view bounds specified as ``(ra_min, ra_max, dec_min, dec_max)``
+            in degrees. RA values are interpreted modulo 360 (degrees) and may
+            be given so that ``ra_min <= ra_max`` for a contiguous RA interval,
+            or ``ra_min > ra_max`` to indicate an interval that wraps across
+            RA=0 (for example ``(350.0, 10.0, -5.0, 5.0)``). Declination bounds
+            must satisfy ``-90 <= dec_min <= dec_max <= 90``.
         filter_bands : Filters, str, or sequence thereof, optional
             One or more filter bands to include as magnitude columns. Accepts a single
             ``Filters`` member or its name as a string, or a list of either.
@@ -354,6 +362,13 @@ class GaiaQuery:
             The sky coordinates of the center of the FOV.
         radius : float or astropy.units.Quantity
             The radius of the FOV in degrees.
+        bounds : tuple or None
+            Field-of-view bounds specified as ``(ra_min, ra_max, dec_min, dec_max)``
+            in degrees. RA values are interpreted modulo 360 (degrees) and may
+            be given so that ``ra_min <= ra_max`` for a contiguous RA interval,
+            or ``ra_min > ra_max`` to indicate an interval that wraps across
+            RA=0 (for example ``(350.0, 10.0, -5.0, 5.0)``). Declination bounds
+            must satisfy ``-90 <= dec_min <= dec_max <= 90``.
         filter_bands : Filters, str, or sequence thereof, optional
             One or more filter bands. Default is ``Filters.G``.
         dateobs : datetime.datetime or None, optional
@@ -448,9 +463,16 @@ class GaiaQuery:
         center : tuple or astropy.coordinates.SkyCoord
             The sky coordinates of the center of the FOV.
             If a tuple is given, it should contain the RA and DEC in degrees.
-        radius : float or astropy.units.Quantity
+        radius : float or astropy.units.Quantity or None
             The radius of the FOV in degrees. If a Quantity is given, it must be
             convertible to degrees.
+        bounds : tuple or None
+            Field-of-view bounds specified as ``(ra_min, ra_max, dec_min, dec_max)``
+            in degrees. RA values are interpreted modulo 360 (degrees) and may
+            be given so that ``ra_min <= ra_max`` for a contiguous RA interval,
+            or ``ra_min > ra_max`` to indicate an interval that wraps across
+            RA=0 (for example ``(350.0, 10.0, -5.0, 5.0)``). Declination bounds
+            must satisfy ``-90 <= dec_min <= dec_max <= 90``.
         filter_band : Filters or str, optional
             The filter to use for the flux column. Default is Filters.G.
         dateobs : datetime.datetime, optional
@@ -538,7 +560,7 @@ class GaiaQuery:
 
         source_text = tap_source.strip()
         if source_text.lower().startswith("sqlite:///"):
-            db_path = source_text[len("sqlite:///"):]
+            db_path = source_text[len("sqlite:///") :]
             if not db_path:
                 raise ValueError("SQLite URI must include a database path.")
             return GaiaSQLiteSource(database=db_path)
@@ -559,6 +581,14 @@ class GaiaQuery:
         """Normalize circle/bounds geometry inputs.
 
         Exactly one of ``radius`` or ``bounds`` must be provided.
+
+        The ``bounds`` tuple should be ``(ra_min, ra_max, dec_min, dec_max)``
+        in degrees. RA values are normalised modulo 360; if ``ra_min <= ra_max``
+        the RA interval is contiguous, otherwise ``ra_min > ra_max`` indicates
+        an interval that wraps across RA=0. Declination bounds must satisfy
+        ``-90 <= dec_min <= dec_max <= 90``. The function returns a tuple of
+        ``(center_coords, radius_deg, bounds_tuple)`` where only the
+        applicable geometry is populated.
         """
         if (radius is None) == (bounds is None):
             raise ValueError(
@@ -589,8 +619,7 @@ class GaiaQuery:
             assert bounds is not None
             if len(bounds) != 4:
                 raise ValueError(
-                    "bounds must be a tuple of "
-                    "(ra_min, ra_max, dec_min, dec_max)."
+                    "bounds must be a tuple of (ra_min, ra_max, dec_min, dec_max)."
                 )
             ra_min, ra_max, dec_min, dec_max = bounds
             dec_min = float(dec_min)
@@ -699,11 +728,18 @@ class GaiaQuery:
             with closing(sqlite3.connect(sqlite_source.database)) as connection:
                 connection.row_factory = sqlite3.Row
                 cursor = connection.cursor()
-                table_name = GaiaQuery._quote_sql_identifier(sqlite_source.table)
+                selected_tables, schema_table = GaiaQuery._select_sqlite_tables(
+                    cursor=cursor,
+                    sqlite_source=sqlite_source,
+                    center=center,
+                    radius_deg=radius_deg,
+                    bounds=bounds,
+                )
+                schema_table_name = GaiaQuery._quote_sql_identifier(schema_table)
 
                 available_columns = {
                     str(row[1])
-                    for row in cursor.execute(f"PRAGMA table_info({table_name})")
+                    for row in cursor.execute(f"PRAGMA table_info({schema_table_name})")
                 }
                 required_position_columns = {"ra", "dec"}
                 missing_required = sorted(required_position_columns - available_columns)
@@ -781,25 +817,35 @@ class GaiaQuery:
                     params.extend(circle_params)
 
                 first_band = selected_bands[0]
-                order_by = GaiaQuery._quote_sql_identifier(first_band.value)
 
-                query_parts = [
-                    f"SELECT {', '.join(select_cols)}",
-                    f"FROM {table_name}",
-                ]
-                if where_sql:
-                    query_parts.append("WHERE " + " AND ".join(where_sql))
-                query_parts.append(f"ORDER BY {order_by} ASC")
-                query_parts.append(f"LIMIT {int(limit)}")
-                sql = "\n".join(query_parts)
-
-                rows = list(cursor.execute(sql, tuple(params)))
                 output_names = ["ra", "dec", "pmra", "pmdec"] + [
                     band.value for band in selected_bands
                 ]
-                output_rows = [
-                    tuple(row[name] for name in output_names) for row in rows
-                ]
+                if not selected_tables:
+                    return Table(rows=[], names=output_names)
+
+                output_rows: list[tuple] = []
+                for table in selected_tables:
+                    table_name = GaiaQuery._quote_sql_identifier(table)
+                    query_parts = [
+                        f"SELECT {', '.join(select_cols)}",
+                        f"FROM {table_name}",
+                    ]
+                    if where_sql:
+                        query_parts.append("WHERE " + " AND ".join(where_sql))
+                    sql = "\n".join(query_parts)
+
+                    rows = list(cursor.execute(sql, tuple(params)))
+                    output_rows.extend(
+                        tuple(
+                            float("nan")
+                            if row[name] is None or row[name] == ""
+                            else row[name]
+                            for name in output_names
+                        )
+                        for row in rows
+                    )
+
                 table = Table(rows=output_rows, names=output_names)
 
                 if radius_deg is not None:
@@ -811,8 +857,15 @@ class GaiaQuery:
                         center_dec=center[1],
                         radius_deg=radius_deg,
                     )
-                    table = table[inside_circle][:limit]
-                return table
+                    table = table[inside_circle]
+
+                if len(table) > 0:
+                    sort_values = np.asarray(
+                        np.ma.filled(table[first_band.value], np.inf),  # type: ignore[index]
+                        dtype=float,
+                    )
+                    table = table[np.argsort(sort_values, kind="stable")]
+                return Table(table[:limit])
 
         return GaiaQuery._run_callable_with_timeout(
             func=_run_query,
@@ -837,6 +890,78 @@ class GaiaQuery:
         else:
             ra_clause = f"({ra_col} >= {ra_min} OR {ra_col} <= {ra_max})"
         return f"{dec_clause} AND {ra_clause}"
+
+    @staticmethod
+    def _select_sqlite_tables(
+        cursor: sqlite3.Cursor,
+        sqlite_source: GaiaSQLiteSource,
+        center: tuple[float, float] | None,
+        radius_deg: float | None,
+        bounds: tuple[float, float, float, float] | None,
+    ) -> tuple[list[str], str]:
+        """Resolve SQLite tables for a query, including dec-ring shards."""
+        all_tables = GaiaQuery._list_sqlite_tables(cursor)
+
+        if sqlite_source.table in all_tables:
+            return [sqlite_source.table], sqlite_source.table
+
+        ring_tables: list[tuple[str, float, float]] = []
+        for table in all_tables:
+            dec_range = GaiaQuery._parse_dec_ring_table_name(table)
+            if dec_range is not None:
+                ring_tables.append((table, dec_range[0], dec_range[1]))
+
+        if not ring_tables:
+            raise ValueError(
+                f"SQLite table '{sqlite_source.table}' not found and no sharded "
+                "declination-ring tables were detected."
+            )
+
+        if bounds is not None:
+            dec_min = bounds[2]
+            dec_max = bounds[3]
+        else:
+            assert center is not None
+            assert radius_deg is not None
+            dec_min = max(-90.0, center[1] - radius_deg)
+            dec_max = min(90.0, center[1] + radius_deg)
+
+        ring_dec_min = {table: tmin for table, tmin, _ in ring_tables}
+
+        selected = sorted(
+            [
+                table
+                for table, ring_min, ring_max in ring_tables
+                if ring_max >= dec_min and ring_min <= dec_max
+            ],
+            key=lambda name: ring_dec_min[name],
+        )
+
+        schema_table = min(ring_tables, key=lambda item: item[1])[0]
+        return selected, schema_table
+
+    @staticmethod
+    def _list_sqlite_tables(cursor: sqlite3.Cursor) -> list[str]:
+        """List user tables in a SQLite database."""
+        return [
+            str(row[0])
+            for row in cursor.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        ]
+
+    @staticmethod
+    def _parse_dec_ring_table_name(table_name: str) -> tuple[float, float] | None:
+        """Parse sharded dec-ring table names such as '-25_-24'."""
+        match = re.match(r"^(-?\d+(?:\.\d+)?)_(-?\d+(?:\.\d+)?)$", table_name)
+        if match is None:
+            return None
+        dec_min = float(match.group(1))
+        dec_max = float(match.group(2))
+        if dec_min > dec_max:
+            return dec_max, dec_min
+        return dec_min, dec_max
 
     @staticmethod
     def _build_sqlite_bounds_where(
@@ -885,12 +1010,9 @@ class GaiaQuery:
         center_ra_rad = math.radians(center_ra)
         center_dec_rad = math.radians(center_dec)
 
-        cos_sep = (
-            np.sin(dec_rad) * math.sin(center_dec_rad)
-            + np.cos(dec_rad)
-            * math.cos(center_dec_rad)
-            * np.cos(ra_rad - center_ra_rad)
-        )
+        cos_sep = np.sin(dec_rad) * math.sin(center_dec_rad) + np.cos(
+            dec_rad
+        ) * math.cos(center_dec_rad) * np.cos(ra_rad - center_ra_rad)
         cos_sep = np.clip(cos_sep, -1.0, 1.0)
         sep_deg = np.degrees(np.arccos(cos_sep))
         return sep_deg <= radius_deg

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -1012,7 +1012,13 @@ class GaiaQuery:
         dec_max = min(90.0, center_dec + radius_deg)
 
         cos_dec = max(abs(math.cos(math.radians(center_dec))), 1e-6)
-        ra_half_width = min(180.0, radius_deg / cos_dec)
+        ra_half_width = radius_deg / cos_dec
+
+        # When the circle is wide enough to span all RA values (e.g. near a pole),
+        # skip the RA filter — only the dec bounds apply.
+        if ra_half_width >= 180.0 or dec_min <= -90.0 or dec_max >= 90.0:
+            return '"dec" >= ? AND "dec" <= ?', (dec_min, dec_max)
+
         ra_min = (center_ra - ra_half_width) % 360.0
         ra_max = (center_ra + ra_half_width) % 360.0
 

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -1,7 +1,12 @@
+import math
+import sqlite3
 import threading
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import closing
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import TypeVar
 
 import numpy as np
 from astropy.coordinates import Angle, SkyCoord
@@ -13,9 +18,28 @@ from cabaret.sources import Sources
 
 __all__ = [
     "Filters",
+    "GaiaSQLiteSource",
     "GaiaTAPSource",
     "GaiaQuery",
 ]
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class GaiaSQLiteSource:
+    """Configuration for querying a local SQLite catalog.
+
+    Parameters
+    ----------
+    database : str
+        Path to the SQLite database file.
+    table : str, optional
+        Catalog table name. Default is ``gaia_sources``.
+    """
+
+    database: str
+    table: str = "gaia_sources"
 
 
 class Filters(Enum):
@@ -211,12 +235,13 @@ class GaiaQuery:
 
     @staticmethod
     def query(
-        center: tuple[float, float] | SkyCoord,
-        radius: float | Angle,
+        center: tuple[float, float] | SkyCoord | None = None,
+        radius: float | Angle | None = None,
+        bounds: tuple[float, float, float, float] | None = None,
         filter_bands: Filters | str | Sequence[Filters | str] = Filters.G,
         limit: int = 100000,
         timeout: float | None = None,
-        tap_source: GaiaTAPSource | str | None = None,
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
         allow_nulls: bool = False,
     ) -> Table:
         """Query a Gaia DR3 TAP service within a given radius around the center.
@@ -267,84 +292,50 @@ class GaiaQuery:
         >>> center = SkyCoord(ra=10.68458, dec=41.26917, unit='deg')
         >>> table = GaiaQuery.query(center, radius=0.1, limit=10, timeout=30)
         """
-        if tap_source is None:
-            tap_source = GaiaQuery.DEFAULT_TAP_SOURCE
-        tap_source = GaiaTAPSource.ensure_enum(tap_source)
-
+        requested_all = isinstance(filter_bands, str) and filter_bands.upper() == "ALL"
         bands = GaiaQuery._normalize_bands(filter_bands)
+        center_coords, radius_deg, bounds_tuple = GaiaQuery._normalize_region(
+            center=center,
+            radius=radius,
+            bounds=bounds,
+        )
+        backend = GaiaQuery._resolve_query_source(tap_source)
 
-        if isinstance(center, SkyCoord):
-            ra = center.ra.deg  # type: ignore
-            dec = center.dec.deg  # type: ignore
+        if isinstance(backend, GaiaTAPSource):
+            table = GaiaQuery._query_tap(
+                tap_source=backend,
+                bands=bands,
+                center=center_coords,
+                radius_deg=radius_deg,
+                bounds=bounds_tuple,
+                limit=limit,
+                timeout=timeout,
+                allow_nulls=allow_nulls,
+            )
         else:
-            ra, dec = center
-
-        cfg = _TAP_CONFIG[tap_source]
-
-        select_cols = [
-            f"{cfg['ra']} AS ra",
-            f"{cfg['dec']} AS dec",
-            f"{cfg['pmra']} AS pmra",
-            f"{cfg['pmdec']} AS pmdec",
-        ]
-        where: list[str] = []
-        joins: list[str] = []
-        need_tmass_join = False
-        seen: set[Filters] = set()
-
-        for band in bands:
-            if band in seen:
-                continue
-            seen.add(band)
-            if Filters.is_tmass(band.name):
-                col_expr = cfg[_TMASS_COL_KEY[band.name]]
-                need_tmass_join = True
-            else:
-                col_expr = cfg[band.name.lower() + "_mag"]
-            select_cols.append(f"{col_expr} AS {band.value}")
-            if not allow_nulls:
-                where.append(f"{col_expr} IS NOT NULL")
-
-        if need_tmass_join:
-            joins.extend(cfg["tmass_joins"])
-
-        # ORDER BY first band, brightest-first: ASC for all magnitude columns.
-        first = bands[0]
-        order_by = f"{first.value} ASC"
-
-        radius = radius.value if isinstance(radius, Quantity) else float(radius)
-        where.append(
-            f"1=CONTAINS("
-            f"POINT('ICRS', {cfg['ra']}, {cfg['dec']}), "
-            f"CIRCLE('ICRS', {ra}, {dec}, {radius}))"
-        )
-
-        select_clause = ", ".join(select_cols)
-        joins_clause = "\n".join(joins)
-        where_clause = " AND ".join(where)
-
-        adql = f"""
-        SELECT TOP {limit} {select_clause}
-        FROM {cfg["from"]}
-        {joins_clause}
-        WHERE {where_clause}
-        ORDER BY {order_by}
-        """
-
-        table = GaiaQuery._launch_job_with_timeout(
-            adql, tap_source=tap_source, timeout=timeout
-        )
+            table = GaiaQuery._query_sqlite(
+                sqlite_source=backend,
+                requested_bands=bands,
+                requested_all=requested_all,
+                center=center_coords,
+                radius_deg=radius_deg,
+                bounds=bounds_tuple,
+                limit=limit,
+                timeout=timeout,
+                allow_nulls=allow_nulls,
+            )
         return table
 
     @staticmethod
     def get_flux_table(
-        center: tuple[float, float] | SkyCoord,
-        radius: float | Angle,
+        center: tuple[float, float] | SkyCoord | None = None,
+        radius: float | Angle | None = None,
+        bounds: tuple[float, float, float, float] | None = None,
         filter_bands: Filters | str | Sequence[Filters | str] = Filters.G,
         dateobs: datetime | None = None,
         limit: int = 100000,
         timeout: float | None = None,
-        tap_source: GaiaTAPSource | str | None = None,
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
         allow_nulls: bool = False,
         keep_mag: bool = False,
     ) -> Table:
@@ -407,6 +398,7 @@ class GaiaQuery:
         table = GaiaQuery.query(
             center=center,
             radius=radius,
+            bounds=bounds,
             filter_bands=bands,
             limit=limit,
             timeout=timeout,
@@ -438,13 +430,14 @@ class GaiaQuery:
 
     @staticmethod
     def get_sources(
-        center: tuple[float, float] | SkyCoord,
-        radius: float | Angle,
+        center: tuple[float, float] | SkyCoord | None = None,
+        radius: float | Angle | None = None,
+        bounds: tuple[float, float, float, float] | None = None,
         filter_band: Filters | str = Filters.G,
         dateobs: datetime | None = None,
         limit: int = 100000,
         timeout: float | None = None,
-        tap_source: GaiaTAPSource | str | None = None,
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
     ) -> Sources:
         """
         Query a Gaia DR3 TAP service to retrieve the RA-DEC coordinates of stars
@@ -505,6 +498,7 @@ class GaiaQuery:
         table = GaiaQuery.query(
             center=center,
             radius=radius,
+            bounds=bounds,
             limit=limit,
             timeout=timeout,
             filter_bands=filter_band,
@@ -526,6 +520,415 @@ class GaiaQuery:
             dec=table["dec"].value.data,  # type: ignore
             fluxes=fluxes,
         )
+
+    @staticmethod
+    def _resolve_query_source(
+        tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None,
+    ) -> GaiaTAPSource | GaiaSQLiteSource:
+        """Resolve a query source into either TAP or SQLite backend config."""
+        if tap_source is None:
+            return GaiaQuery.DEFAULT_TAP_SOURCE
+        if isinstance(tap_source, GaiaSQLiteSource | GaiaTAPSource):
+            return tap_source
+        if not isinstance(tap_source, str):
+            raise ValueError(
+                "tap_source must be a GaiaTAPSource, GaiaSQLiteSource, or str, "
+                f"got {type(tap_source)}"
+            )
+
+        source_text = tap_source.strip()
+        if source_text.lower().startswith("sqlite:///"):
+            db_path = source_text[len("sqlite:///"):]
+            if not db_path:
+                raise ValueError("SQLite URI must include a database path.")
+            return GaiaSQLiteSource(database=db_path)
+        if source_text.lower().endswith((".db", ".sqlite", ".sqlite3")):
+            return GaiaSQLiteSource(database=source_text)
+        return GaiaTAPSource.ensure_enum(source_text)
+
+    @staticmethod
+    def _normalize_region(
+        center: tuple[float, float] | SkyCoord | None,
+        radius: float | Angle | None,
+        bounds: tuple[float, float, float, float] | None,
+    ) -> tuple[
+        tuple[float, float] | None,
+        float | None,
+        tuple[float, float, float, float] | None,
+    ]:
+        """Normalize circle/bounds geometry inputs.
+
+        Exactly one of ``radius`` or ``bounds`` must be provided.
+        """
+        if (radius is None) == (bounds is None):
+            raise ValueError(
+                "Exactly one geometry must be specified: either radius or bounds."
+            )
+
+        center_coords: tuple[float, float] | None = None
+        radius_deg: float | None = None
+        bounds_tuple: tuple[float, float, float, float] | None = None
+
+        if radius is not None:
+            if center is None:
+                raise ValueError("center must be provided for radius-based queries.")
+            radius_value = (
+                radius.value if isinstance(radius, Quantity) else float(radius)
+            )
+            if radius_value <= 0:
+                raise ValueError("radius must be > 0.")
+            radius_deg = radius_value
+            if isinstance(center, SkyCoord):
+                center_coords = (
+                    float(center.ra.deg % 360.0),  # type: ignore
+                    float(center.dec.deg),  # type: ignore
+                )
+            else:
+                center_coords = (float(center[0] % 360.0), float(center[1]))
+        else:
+            assert bounds is not None
+            if len(bounds) != 4:
+                raise ValueError(
+                    "bounds must be a tuple of "
+                    "(ra_min, ra_max, dec_min, dec_max)."
+                )
+            ra_min, ra_max, dec_min, dec_max = bounds
+            dec_min = float(dec_min)
+            dec_max = float(dec_max)
+            if dec_min > dec_max:
+                raise ValueError("dec_min must be <= dec_max.")
+            if dec_min < -90.0 or dec_max > 90.0:
+                raise ValueError("declination bounds must stay within [-90, 90].")
+            bounds_tuple = (
+                float(ra_min % 360.0),
+                float(ra_max % 360.0),
+                dec_min,
+                dec_max,
+            )
+
+        return center_coords, radius_deg, bounds_tuple
+
+    @staticmethod
+    def _query_tap(
+        tap_source: GaiaTAPSource,
+        bands: list[Filters],
+        center: tuple[float, float] | None,
+        radius_deg: float | None,
+        bounds: tuple[float, float, float, float] | None,
+        limit: int,
+        timeout: float | None,
+        allow_nulls: bool,
+    ) -> Table:
+        """Execute a Gaia query against a TAP backend."""
+        cfg = _TAP_CONFIG[tap_source]
+
+        select_cols = [
+            f"{cfg['ra']} AS ra",
+            f"{cfg['dec']} AS dec",
+            f"{cfg['pmra']} AS pmra",
+            f"{cfg['pmdec']} AS pmdec",
+        ]
+        where: list[str] = []
+        joins: list[str] = []
+        need_tmass_join = False
+
+        for band in bands:
+            if Filters.is_tmass(band.name):
+                col_expr = cfg[_TMASS_COL_KEY[band.name]]
+                need_tmass_join = True
+            else:
+                col_expr = cfg[band.name.lower() + "_mag"]
+            select_cols.append(f"{col_expr} AS {band.value}")
+            if not allow_nulls:
+                where.append(f"{col_expr} IS NOT NULL")
+
+        if need_tmass_join:
+            joins.extend(cfg["tmass_joins"])
+
+        first = bands[0]
+        order_by = f"{first.value} ASC"
+
+        if radius_deg is not None:
+            assert center is not None
+            where.append(
+                f"1=CONTAINS("
+                f"POINT('ICRS', {cfg['ra']}, {cfg['dec']}), "
+                f"CIRCLE('ICRS', {center[0]}, {center[1]}, {radius_deg}))"
+            )
+        else:
+            assert bounds is not None
+            where.append(
+                GaiaQuery._build_tap_bounds_where(
+                    cfg["ra"],
+                    cfg["dec"],
+                    bounds,
+                )
+            )
+
+        select_clause = ", ".join(select_cols)
+        joins_clause = "\n".join(joins)
+        where_clause = " AND ".join(where)
+
+        adql = f"""
+        SELECT TOP {limit} {select_clause}
+        FROM {cfg["from"]}
+        {joins_clause}
+        WHERE {where_clause}
+        ORDER BY {order_by}
+        """
+
+        return GaiaQuery._launch_job_with_timeout(
+            adql, tap_source=tap_source, timeout=timeout
+        )
+
+    @staticmethod
+    def _query_sqlite(
+        sqlite_source: GaiaSQLiteSource,
+        requested_bands: list[Filters],
+        requested_all: bool,
+        center: tuple[float, float] | None,
+        radius_deg: float | None,
+        bounds: tuple[float, float, float, float] | None,
+        limit: int,
+        timeout: float | None,
+        allow_nulls: bool,
+    ) -> Table:
+        """Execute a Gaia-like query against a local SQLite catalog."""
+
+        def _run_query() -> Table:
+            with closing(sqlite3.connect(sqlite_source.database)) as connection:
+                connection.row_factory = sqlite3.Row
+                cursor = connection.cursor()
+                table_name = GaiaQuery._quote_sql_identifier(sqlite_source.table)
+
+                available_columns = {
+                    str(row[1])
+                    for row in cursor.execute(f"PRAGMA table_info({table_name})")
+                }
+                required_position_columns = {"ra", "dec"}
+                missing_required = sorted(required_position_columns - available_columns)
+                if missing_required:
+                    raise ValueError(
+                        "SQLite source is missing required columns: "
+                        f"{', '.join(missing_required)}"
+                    )
+
+                if requested_all:
+                    selected_bands = [
+                        band
+                        for band in requested_bands
+                        if band.value in available_columns
+                    ]
+                    if not selected_bands:
+                        raise ValueError(
+                            "SQLite source does not contain any supported "
+                            "magnitude columns."
+                        )
+                else:
+                    missing_requested = [
+                        band.value
+                        for band in requested_bands
+                        if band.value not in available_columns
+                    ]
+                    if missing_requested:
+                        raise ValueError(
+                            "SQLite source is missing requested band columns: "
+                            f"{', '.join(sorted(missing_requested))}"
+                        )
+                    selected_bands = requested_bands
+
+                select_cols = [
+                    '"ra" AS ra',
+                    '"dec" AS dec',
+                    (
+                        '"pmra" AS pmra'
+                        if "pmra" in available_columns
+                        else "NULL AS pmra"
+                    ),
+                    (
+                        '"pmdec" AS pmdec'
+                        if "pmdec" in available_columns
+                        else "NULL AS pmdec"
+                    ),
+                ]
+                for band in selected_bands:
+                    quoted_col = GaiaQuery._quote_sql_identifier(band.value)
+                    select_cols.append(f"{quoted_col} AS {band.value}")
+
+                where_sql: list[str] = []
+                params: list[float] = []
+                if not allow_nulls:
+                    for band in selected_bands:
+                        quoted_col = GaiaQuery._quote_sql_identifier(band.value)
+                        where_sql.append(f"{quoted_col} IS NOT NULL")
+
+                if bounds is not None:
+                    bounds_sql, bounds_params = GaiaQuery._build_sqlite_bounds_where(
+                        bounds
+                    )
+                    where_sql.append(bounds_sql)
+                    params.extend(bounds_params)
+                else:
+                    assert center is not None
+                    assert radius_deg is not None
+                    circle_sql, circle_params = (
+                        GaiaQuery._build_sqlite_circle_prefilter_where(
+                            center=center,
+                            radius_deg=radius_deg,
+                        )
+                    )
+                    where_sql.append(circle_sql)
+                    params.extend(circle_params)
+
+                first_band = selected_bands[0]
+                order_by = GaiaQuery._quote_sql_identifier(first_band.value)
+
+                query_parts = [
+                    f"SELECT {', '.join(select_cols)}",
+                    f"FROM {table_name}",
+                ]
+                if where_sql:
+                    query_parts.append("WHERE " + " AND ".join(where_sql))
+                query_parts.append(f"ORDER BY {order_by} ASC")
+                query_parts.append(f"LIMIT {int(limit)}")
+                sql = "\n".join(query_parts)
+
+                rows = list(cursor.execute(sql, tuple(params)))
+                output_names = ["ra", "dec", "pmra", "pmdec"] + [
+                    band.value for band in selected_bands
+                ]
+                output_rows = [
+                    tuple(row[name] for name in output_names) for row in rows
+                ]
+                table = Table(rows=output_rows, names=output_names)
+
+                if radius_deg is not None:
+                    assert center is not None
+                    inside_circle = GaiaQuery._on_sky_circle_mask(
+                        ra=np.asarray(table["ra"], dtype=float),
+                        dec=np.asarray(table["dec"], dtype=float),
+                        center_ra=center[0],
+                        center_dec=center[1],
+                        radius_deg=radius_deg,
+                    )
+                    table = table[inside_circle][:limit]
+                return table
+
+        return GaiaQuery._run_callable_with_timeout(
+            func=_run_query,
+            timeout=timeout,
+            timeout_message=(
+                "SQLite Gaia query timed out. "
+                "You may want to increase the timeout or reduce the query size."
+            ),
+        )
+
+    @staticmethod
+    def _build_tap_bounds_where(
+        ra_col: str,
+        dec_col: str,
+        bounds: tuple[float, float, float, float],
+    ) -> str:
+        """Build an ADQL bounds predicate with RA wrap handling."""
+        ra_min, ra_max, dec_min, dec_max = bounds
+        dec_clause = f"({dec_col} >= {dec_min} AND {dec_col} <= {dec_max})"
+        if ra_min <= ra_max:
+            ra_clause = f"({ra_col} >= {ra_min} AND {ra_col} <= {ra_max})"
+        else:
+            ra_clause = f"({ra_col} >= {ra_min} OR {ra_col} <= {ra_max})"
+        return f"{dec_clause} AND {ra_clause}"
+
+    @staticmethod
+    def _build_sqlite_bounds_where(
+        bounds: tuple[float, float, float, float],
+    ) -> tuple[str, tuple[float, ...]]:
+        """Build SQL bounds predicate with parameters and RA wrap handling."""
+        ra_min, ra_max, dec_min, dec_max = bounds
+        if ra_min <= ra_max:
+            return (
+                '("dec" >= ? AND "dec" <= ?) AND ("ra" >= ? AND "ra" <= ?)',
+                (dec_min, dec_max, ra_min, ra_max),
+            )
+        return (
+            '("dec" >= ? AND "dec" <= ?) AND (("ra" >= ?) OR ("ra" <= ?))',
+            (dec_min, dec_max, ra_min, ra_max),
+        )
+
+    @staticmethod
+    def _build_sqlite_circle_prefilter_where(
+        center: tuple[float, float],
+        radius_deg: float,
+    ) -> tuple[str, tuple[float, ...]]:
+        """Build a rectangular SQL prefilter around a circle query."""
+        center_ra, center_dec = center
+        dec_min = max(-90.0, center_dec - radius_deg)
+        dec_max = min(90.0, center_dec + radius_deg)
+
+        cos_dec = max(abs(math.cos(math.radians(center_dec))), 1e-6)
+        ra_half_width = min(180.0, radius_deg / cos_dec)
+        ra_min = (center_ra - ra_half_width) % 360.0
+        ra_max = (center_ra + ra_half_width) % 360.0
+
+        return GaiaQuery._build_sqlite_bounds_where((ra_min, ra_max, dec_min, dec_max))
+
+    @staticmethod
+    def _on_sky_circle_mask(
+        ra: np.ndarray,
+        dec: np.ndarray,
+        center_ra: float,
+        center_dec: float,
+        radius_deg: float,
+    ) -> np.ndarray:
+        """Return mask for points within an angular radius on the sphere."""
+        ra_rad = np.radians(ra)
+        dec_rad = np.radians(dec)
+        center_ra_rad = math.radians(center_ra)
+        center_dec_rad = math.radians(center_dec)
+
+        cos_sep = (
+            np.sin(dec_rad) * math.sin(center_dec_rad)
+            + np.cos(dec_rad)
+            * math.cos(center_dec_rad)
+            * np.cos(ra_rad - center_ra_rad)
+        )
+        cos_sep = np.clip(cos_sep, -1.0, 1.0)
+        sep_deg = np.degrees(np.arccos(cos_sep))
+        return sep_deg <= radius_deg
+
+    @staticmethod
+    def _quote_sql_identifier(identifier: str) -> str:
+        """Quote a SQLite identifier safely."""
+        if not identifier:
+            raise ValueError("SQL identifier cannot be empty.")
+        return '"' + identifier.replace('"', '""') + '"'
+
+    @staticmethod
+    def _run_callable_with_timeout(
+        func: Callable[[], _T],
+        timeout: float | None,
+        timeout_message: str,
+    ) -> _T:
+        """Run a callable with optional timeout using a daemon thread."""
+        if timeout is None:
+            return func()
+
+        result: list[_T] = []
+        exc: list = []
+
+        def _run_safe():
+            try:
+                result.append(func())
+            except Exception as e:
+                exc.append(e)
+
+        t = threading.Thread(target=_run_safe, daemon=True)
+        t.start()
+        t.join(timeout=timeout)
+        if t.is_alive():
+            raise TimeoutError(timeout_message)
+        if exc:
+            raise exc[0]
+        return result[0]
 
     @staticmethod
     def _launch_job_with_timeout(
@@ -561,35 +964,20 @@ class GaiaQuery:
         """
         from astroquery.utils.tap.core import TapPlus
 
-        def _run():
+        def _run() -> Table:
             tap = TapPlus(url=tap_source.value)
             job = tap.launch_job(query, **kwargs)
-            return job.get_results()  # type: ignore
+            return Table(job.get_results())  # type: ignore[arg-type]
 
-        if timeout is None:
-            return _run()
-
-        result: list = []
-        exc: list = []
-
-        def _run_safe():
-            try:
-                result.append(_run())
-            except Exception as e:
-                exc.append(e)
-
-        t = threading.Thread(target=_run_safe, daemon=True)
-        t.start()
-        t.join(timeout=timeout)
-        if t.is_alive():
-            raise TimeoutError(
-                "Gaia query timed out."
-                " You may want to increase the timeout or reduce the query size."
-                f" Query was: {query}"
-            )
-        if exc:
-            raise exc[0]
-        return result[0]
+        return GaiaQuery._run_callable_with_timeout(
+            func=_run,
+            timeout=timeout,
+            timeout_message=(
+                "Gaia query timed out. "
+                "You may want to increase the timeout or reduce the query size. "
+                f"Query was: {query}"
+            ),
+        )
 
     # Vega zero-points for all supported bands.
     # See _derive_band_properties for how these were obtained.
@@ -666,7 +1054,7 @@ class GaiaQuery:
     def _normalize_bands(
         filter_bands: Filters | str | Sequence[Filters | str],
     ) -> list["Filters"]:
-        """Normalize filter_bands argument to a list[Filters].
+        """Normalize filter_bands argument to a deduplicated list[Filters].
 
         Passing the string ``"all"`` (case-insensitive) expands to every
         available filter, equivalent to ``Filters.all()``.
@@ -682,7 +1070,7 @@ class GaiaQuery:
             )
         if not filter_bands:
             raise ValueError("At least one filter_band must be specified.")
-        return [Filters.ensure_enum(b) for b in filter_bands]
+        return list(dict.fromkeys(Filters.ensure_enum(b) for b in filter_bands))
 
     @staticmethod
     def _derive_band_properties():

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -211,10 +211,12 @@ class GaiaQuery:
     either the raw Astropy Table, a flux-normalised multi-band Table, or a
     Sources instance with RA-DEC coordinates and fluxes.
 
-    The TAP service is selected via ``GaiaQuery.DEFAULT_TAP_SOURCE`` (class
-    level) or the per-call ``tap_source`` argument.  The default is
-    ``GaiaTAPSource.VIZIER`` (CDS VizieR), which hosts a copy of Gaia DR3 and
-    is a reliable fallback when the ESA Gaia Archive is unavailable.
+    The query backend is selected via ``GaiaQuery.DEFAULT_TAP_SOURCE`` (class
+    level) or the per-call ``tap_source`` argument.  Accepts a
+    ``GaiaTAPSource`` for an online TAP service, a ``GaiaSQLiteSource`` for an
+    offline SQLite database, a TAP endpoint URL, a ``sqlite:///...`` URI, or a
+    direct path to a ``.db``/``.sqlite``/``.sqlite3`` file.  The default is
+    ``GaiaTAPSource.VIZIER`` (CDS VizieR), which hosts a copy of Gaia DR3.
 
     Examples
     --------
@@ -231,7 +233,7 @@ class GaiaQuery:
     >>> sources = GaiaQuery.get_sources(center, radius=0.05, limit=10, timeout=30)
     """
 
-    DEFAULT_TAP_SOURCE: GaiaTAPSource = GaiaTAPSource.VIZIER
+    DEFAULT_TAP_SOURCE: GaiaTAPSource | GaiaSQLiteSource | str = GaiaTAPSource.VIZIER
     """Default TAP service used when ``tap_source=None`` is passed to query methods."""
 
     @staticmethod
@@ -276,10 +278,12 @@ class GaiaQuery:
         timeout : float, optional
             The maximum time to wait for the Gaia query to complete, in seconds.
             If None, there is no timeout. By default, it is set to None.
-        tap_source : GaiaTAPSource, str, or None, optional
-            TAP service to query. Accepts a ``GaiaTAPSource`` member or its name
-            as a string (e.g. ``"GAIA"`` or ``"VIZIER"``). If None, uses
-            ``GaiaQuery.DEFAULT_TAP_SOURCE`` (default: ``GaiaTAPSource.VIZIER``).
+        tap_source : GaiaTAPSource, GaiaSQLiteSource, str, or None, optional
+            Query backend to use. Accepts a ``GaiaTAPSource`` for an online TAP
+            service, a ``GaiaSQLiteSource`` for an offline SQLite database, a TAP
+            endpoint URL as a string, a ``sqlite:///...`` URI, or a direct path to
+            a SQLite database file ending in ``.db``, ``.sqlite``, or
+            ``.sqlite3``. If None, the default TAP backend is used.
         allow_nulls : bool, optional
             If False (default), only rows where all requested band columns are
             non-NULL are returned (``IS NOT NULL`` filter per band). Set to True
@@ -377,8 +381,10 @@ class GaiaQuery:
             Maximum number of sources to retrieve. Default is 100000.
         timeout : float or None, optional
             Query timeout in seconds. Default is None (no timeout).
-        tap_source : GaiaTAPSource, str, or None, optional
-            TAP service to query. Default is ``GaiaQuery.DEFAULT_TAP_SOURCE``.
+        tap_source : GaiaTAPSource, GaiaSQLiteSource, str, or None, optional
+            Query backend to use. Accepts a ``GaiaTAPSource``, ``GaiaSQLiteSource``,
+            TAP URL, ``sqlite:///...`` URI, or ``.db``/``.sqlite``/``.sqlite3`` path.
+            Default is ``GaiaQuery.DEFAULT_TAP_SOURCE``.
         allow_nulls : bool, optional
             Forwarded to :meth:`query`. If True, rows with NULL magnitude values
             are included in the result. Default is False.
@@ -484,10 +490,12 @@ class GaiaQuery:
         timeout : float, optional
             The maximum time to wait for the Gaia query to complete, in seconds.
             If None, there is no timeout. By default, it is set to None.
-        tap_source : GaiaTAPSource, str, or None, optional
-            TAP service to query. Accepts a ``GaiaTAPSource`` member or its name
-            as a string (e.g. ``"GAIA"`` or ``"VIZIER"``). If None, uses
-            ``GaiaQuery.DEFAULT_TAP_SOURCE`` (default: ``GaiaTAPSource.VIZIER``).
+        tap_source : GaiaTAPSource, GaiaSQLiteSource, str, or None, optional
+            Query backend to use. Accepts a ``GaiaTAPSource`` for an online TAP
+            service, a ``GaiaSQLiteSource`` for an offline SQLite database, a TAP
+            endpoint URL as a string, a ``sqlite:///...`` URI, or a direct path to
+            a SQLite database file ending in ``.db``, ``.sqlite``, or
+            ``.sqlite3``. If None, the default TAP backend is used.
 
         Returns
         -------
@@ -724,9 +732,11 @@ class GaiaQuery:
     ) -> Table:
         """Execute a Gaia-like query against a local SQLite catalog."""
 
+        connection = sqlite3.connect(sqlite_source.database, check_same_thread=False)
+        connection.row_factory = sqlite3.Row
+
         def _run_query() -> Table:
-            with closing(sqlite3.connect(sqlite_source.database)) as connection:
-                connection.row_factory = sqlite3.Row
+            with closing(connection):
                 cursor = connection.cursor()
                 selected_tables, schema_table = GaiaQuery._select_sqlite_tables(
                     cursor=cursor,
@@ -874,6 +884,7 @@ class GaiaQuery:
                 "SQLite Gaia query timed out. "
                 "You may want to increase the timeout or reduce the query size."
             ),
+            on_timeout=connection.interrupt,
         )
 
     @staticmethod
@@ -1029,6 +1040,7 @@ class GaiaQuery:
         func: Callable[[], _T],
         timeout: float | None,
         timeout_message: str,
+        on_timeout: Callable[[], None] | None = None,
     ) -> _T:
         """Run a callable with optional timeout using a daemon thread."""
         if timeout is None:
@@ -1047,6 +1059,8 @@ class GaiaQuery:
         t.start()
         t.join(timeout=timeout)
         if t.is_alive():
+            if on_timeout is not None:
+                on_timeout()
             raise TimeoutError(timeout_message)
         if exc:
             raise exc[0]

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -229,6 +229,40 @@ def _make_sqlite_catalog(path: str):
         conn.close()
 
 
+def _make_sharded_sqlite_catalog(path: str):
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            'CREATE TABLE "-1_0" ('
+            "ra REAL, dec REAL, pmra REAL, pmdec REAL, phot_g_mean_mag REAL"
+            ")"
+        )
+        conn.execute(
+            'CREATE TABLE "0_1" ('
+            "ra REAL, dec REAL, pmra REAL, pmdec REAL, phot_g_mean_mag REAL"
+            ")"
+        )
+        conn.executemany(
+            'INSERT INTO "-1_0" (ra, dec, pmra, pmdec, phot_g_mean_mag) '
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (20.0, -0.6, 0.0, 0.0, 13.0),
+                (10.0, -0.2, 0.0, 0.0, 12.0),
+            ],
+        )
+        conn.executemany(
+            'INSERT INTO "0_1" (ra, dec, pmra, pmdec, phot_g_mean_mag) '
+            "VALUES (?, ?, ?, ?, ?)",
+            [
+                (40.0, 0.2, 0.0, 0.0, 11.0),
+                (30.0, 0.6, 0.0, 0.0, 10.0),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def test_query_sqlite_by_radius(tmp_path):
     db_path = tmp_path / "gaia_offline.db"
     _make_sqlite_catalog(str(db_path))
@@ -305,3 +339,35 @@ def test_get_sources_sqlite_bounds(tmp_path):
 
     assert len(sources) == 2
     assert np.all(sources.fluxes > 0)
+
+
+def test_query_sqlite_sharded_auto_detect_bounds(tmp_path):
+    db_path = tmp_path / "gaia_sharded.db"
+    _make_sharded_sqlite_catalog(str(db_path))
+
+    table = GaiaQuery.query(
+        bounds=(0.0, 60.0, -0.3, 0.3),
+        filter_bands=Filters.G,
+        limit=10,
+        tap_source=GaiaSQLiteSource(database=str(db_path)),
+    )
+
+    assert len(table) == 2
+    assert np.all((-0.3 <= table["dec"]) & (table["dec"] <= 0.3))
+
+
+def test_query_sqlite_sharded_auto_detect_radius(tmp_path):
+    db_path = tmp_path / "gaia_sharded.db"
+    _make_sharded_sqlite_catalog(str(db_path))
+
+    table = GaiaQuery.query(
+        center=(30.0, 0.0),
+        radius=30.0,
+        filter_bands="G",
+        limit=10,
+        tap_source=f"sqlite:///{db_path}",
+    )
+
+    assert len(table) == 4
+    assert np.all(table["dec"] >= -1.0)
+    assert np.all(table["dec"] <= 1.0)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -356,6 +356,92 @@ def test_query_sqlite_sharded_auto_detect_bounds(tmp_path):
     assert np.all((-0.3 <= table["dec"]) & (table["dec"] <= 0.3))
 
 
+def _make_sky_catalog(path: str, rows: list[tuple]):
+    """rows: (ra, dec, phot_g_mean_mag)"""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE gaia_sources "
+            "(ra REAL, dec REAL, pmra REAL, pmdec REAL, phot_g_mean_mag REAL)"
+        )
+        conn.executemany(
+            "INSERT INTO gaia_sources VALUES (?, ?, NULL, NULL, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _query_ra_set(db_path: str, center: tuple, radius: float) -> set[float]:
+    table = GaiaQuery.query(
+        center=center,
+        radius=radius,
+        filter_bands="G",
+        limit=100,
+        tap_source=GaiaSQLiteSource(database=db_path),
+    )
+    return set(np.round(table["ra"], 1).tolist())
+
+
+def test_sqlite_radius_ra_wrap_straddles_zero(tmp_path):
+    """Stars straddling RA=0 must both appear when the circle crosses the wrap."""
+    db = str(tmp_path / "cat.db")
+    _make_sky_catalog(
+        db,
+        [
+            (359.5, 0.0, 10.0),  # 0.5° west of RA=0 — inside
+            (0.5, 0.0, 11.0),  # 0.5° east of RA=0 — inside
+            (5.0, 0.0, 12.0),  # 5° east — outside
+            (355.0, 0.0, 13.0),  # 5° west — outside
+        ],
+    )
+    assert _query_ra_set(db, center=(0.0, 0.0), radius=2.0) == {359.5, 0.5}
+
+
+def test_sqlite_radius_ra_wrap_center_near_360(tmp_path):
+    """Circle centered at RA=359 must capture a star that wraps past RA=0."""
+    db = str(tmp_path / "cat.db")
+    _make_sky_catalog(
+        db,
+        [
+            (1.0, 0.0, 10.0),  # 2° east via wrap — inside
+            (357.0, 0.0, 11.0),  # 2° west — inside
+            (5.0, 0.0, 12.0),  # 6° east via wrap — outside
+        ],
+    )
+    assert _query_ra_set(db, center=(359.0, 0.0), radius=3.0) == {1.0, 357.0}
+
+
+def test_sqlite_radius_near_north_pole_all_ra(tmp_path):
+    """Stars near the pole at opposite RA must be found."""
+    db = str(tmp_path / "cat.db")
+    # (RA=0, Dec=89) → (RA=180, Dec=89.5): great-circle separation ≈ 1.5° < 2°
+    _make_sky_catalog(
+        db,
+        [
+            (0.0, 89.5, 10.0),  # same RA as center — inside
+            (180.0, 89.5, 11.0),  # opposite RA, ~1.5° away — inside
+            (90.0, 87.5, 12.0),  # ~2.5° from center — outside
+        ],
+    )
+    assert _query_ra_set(db, center=(0.0, 89.0), radius=2.0) == {0.0, 180.0}
+
+
+def test_sqlite_radius_near_south_pole_all_ra(tmp_path):
+    """Same as north-pole test, mirrored to Dec=-89."""
+    db = str(tmp_path / "cat.db")
+    _make_sky_catalog(
+        db,
+        [
+            (0.0, -89.5, 10.0),
+            (180.0, -89.5, 11.0),
+            (90.0, -87.5, 12.0),
+        ],
+    )
+    assert _query_ra_set(db, center=(0.0, -89.0), radius=2.0) == {0.0, 180.0}
+
+
 def test_query_sqlite_sharded_auto_detect_radius(tmp_path):
     db_path = tmp_path / "gaia_sharded.db"
     _make_sharded_sqlite_catalog(str(db_path))

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,8 +1,10 @@
+import sqlite3
+
 import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 
-from cabaret.queries import Filters, GaiaQuery, GaiaTAPSource
+from cabaret.queries import Filters, GaiaQuery, GaiaSQLiteSource, GaiaTAPSource
 from cabaret.sources import Sources
 
 from .utils import has_tap_source
@@ -194,3 +196,112 @@ def test_drop_nan_fluxes_no_nans_returns_self():
         fluxes=np.array([100.0, 200.0]),
     )
     assert sources.drop_nan_fluxes() is sources
+
+
+def _make_sqlite_catalog(path: str):
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE gaia_sources (
+                ra REAL,
+                dec REAL,
+                pmra REAL,
+                pmdec REAL,
+                phot_g_mean_mag REAL,
+                h_m REAL
+            )
+            """
+        )
+        rows = [
+            (359.9, 0.0, 1.0, 2.0, 10.0, 9.0),
+            (0.2, 0.1, 0.0, 0.0, 11.0, 10.0),
+            (15.0, 2.0, None, None, 13.0, 12.0),
+            (45.0, 20.0, -1.0, 0.5, 12.0, None),
+        ]
+        conn.executemany(
+            "INSERT INTO gaia_sources (ra, dec, pmra, pmdec, phot_g_mean_mag, h_m) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_query_sqlite_by_radius(tmp_path):
+    db_path = tmp_path / "gaia_offline.db"
+    _make_sqlite_catalog(str(db_path))
+
+    table = GaiaQuery.query(
+        center=(0.0, 0.0),
+        radius=1.0,
+        filter_bands="G",
+        limit=10,
+        tap_source=GaiaSQLiteSource(database=str(db_path)),
+    )
+
+    assert len(table) == 2
+    assert "phot_g_mean_mag" in table.colnames
+    assert np.all(table["phot_g_mean_mag"] >= 10.0)
+
+
+def test_query_sqlite_by_bounds_wraparound(tmp_path):
+    db_path = tmp_path / "gaia_offline.db"
+    _make_sqlite_catalog(str(db_path))
+
+    table = GaiaQuery.query(
+        bounds=(359.5, 0.5, -1.0, 1.0),
+        filter_bands="G",
+        limit=10,
+        tap_source=f"sqlite:///{db_path}",
+    )
+
+    assert len(table) == 2
+    assert np.all((table["ra"] > 359.5) | (table["ra"] < 0.5))
+
+
+def test_query_sqlite_filter_bands_all_partial_schema(tmp_path):
+    db_path = tmp_path / "gaia_offline.db"
+    _make_sqlite_catalog(str(db_path))
+
+    table = GaiaQuery.query(
+        center=(15.0, 2.0),
+        radius=2.0,
+        filter_bands="all",
+        limit=10,
+        tap_source=GaiaSQLiteSource(database=str(db_path)),
+    )
+
+    assert "phot_g_mean_mag" in table.colnames
+    assert "h_m" in table.colnames
+    assert "phot_bp_mean_mag" not in table.colnames
+
+
+def test_query_sqlite_missing_explicit_band_raises(tmp_path):
+    db_path = tmp_path / "gaia_offline.db"
+    _make_sqlite_catalog(str(db_path))
+
+    with pytest.raises(ValueError, match="missing requested band columns"):
+        GaiaQuery.query(
+            center=(15.0, 2.0),
+            radius=2.0,
+            filter_bands=[Filters.BP],
+            limit=10,
+            tap_source=GaiaSQLiteSource(database=str(db_path)),
+        )
+
+
+def test_get_sources_sqlite_bounds(tmp_path):
+    db_path = tmp_path / "gaia_offline.db"
+    _make_sqlite_catalog(str(db_path))
+
+    sources = GaiaQuery.get_sources(
+        bounds=(359.5, 0.5, -1.0, 1.0),
+        filter_band=Filters.G,
+        limit=10,
+        tap_source=GaiaSQLiteSource(database=str(db_path)),
+    )
+
+    assert len(sources) == 2
+    assert np.all(sources.fluxes > 0)

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "cabaret"
-version = "0.4.8"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
@@ -766,11 +766,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Add offline SQLite catalog support (`GaiaSQLiteSource`)

**Summary**

- Adds `GaiaSQLiteSource` — a new backend that lets `GaiaQuery` query a local SQLite file instead of a remote TAP service, enabling low-latency queries and offline use.
- Extends `GaiaQuery.query()` and `get_flux_table()` with a `bounds` parameter accepting `(ra_min, ra_max, dec_min, dec_max)` as an alternative to center+radius, with correct RA wraparound handling across RA=0.
- Auto-detects sharded (declination-ring) catalogs: if the configured table is missing, Cabaret discovers `<lo>_<hi>` ring tables and queries only the overlapping shards.
- Accepts SQLite source as a `GaiaSQLiteSource` instance, a `sqlite:///...` URI, or a plain path ending in `.db`/`.sqlite`/`.sqlite3`.
- `GaiaSQLiteSource` is now exported from the top-level `cabaret` namespace.

**What changed**

| Area | Change |
|---|---|
| `queries.py` | New `GaiaSQLiteSource` dataclass; `query()` dispatches to `_query_tap` or `_query_sqlite` based on backend type; `bounds` geometry added throughout |
| `image.py`, `observatory.py` | `tap_source` type hints updated to include `GaiaSQLiteSource`; `bounds` threaded through `get_sources` |
| `__init__.py` | `GaiaSQLiteSource` added to public API |
| `docs/source/local_catalog.md` | New page documenting SQLite usage, sharded catalogs, RA wraparound, and a worked example using the prebuilt Zenodo catalog |
| `README.md` | Added *Offline SQLite Catalogs* quick-start section |

**Test plan**
- [x] Unit tests in `tests/test_queries.py` cover SQLite querying, sharded catalog auto-detection, and RA wraparound bounds
- [x] Verify against the prebuilt `gaia_tmass_7_jm_cut.db` catalog from Zenodo
