### PR TITLE
feat: add relative-motion star trailing and moving-target tracking

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -23,6 +23,7 @@ citation
 
 notebooks/configuring_an_observatory.ipynb
 notebooks/multi_band_query.ipynb
+notebooks/asteroid_trailing.ipynb
 ```
 
 ```{toctree}

--- a/docs/source/notebooks/asteroid_trailing.ipynb
+++ b/docs/source/notebooks/asteroid_trailing.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ad0c9a5e",
+   "metadata": {},
+   "source": [
+    "# Asteroid Tracking Simulation\n",
+    "\n",
+    "In *tracking* mode, the telescope slews to follow a moving target — the asteroid stays\n",
+    "fixed as a point source while background stars trail across the detector.\n",
+    "\n",
+    "This notebook simulates that scenario across 5 consecutive exposures of the near-Earth\n",
+    "asteroid **2024 MK**, using real ephemerides from JPL Horizons."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adb4d177",
+   "metadata": {},
+   "source": [
+    "## 1. Fetch the ephemeris from JPL Horizons\n",
+    "\n",
+    "We query Horizons for the asteroid's sky position and angular velocity at the mid-time\n",
+    "of each exposure. The cadence is `exposure_time + processing_time` seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ff31603",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.time import Time, TimeDelta\n",
+    "from astroquery.jplhorizons import Horizons\n",
+    "\n",
+    "start_time = Time(\"2024-06-29T13:00:00\", format=\"isot\")\n",
+    "exposure_time = 5.0  # seconds\n",
+    "processing_time = 1.0  # seconds\n",
+    "n_exposures = 5\n",
+    "\n",
+    "epochs = [\n",
+    "    (start_time + TimeDelta(i * (exposure_time + processing_time), format=\"sec\")).jd\n",
+    "    for i in range(n_exposures)\n",
+    "]\n",
+    "\n",
+    "# A bright near-Earth asteroid with significant motion during the exposures\n",
+    "target_id = \"2024 MK\"\n",
+    "location = \"807\"  # Cerro Paranal (ESO)\n",
+    "\n",
+    "obj = Horizons(id=target_id, location=location, epochs=epochs)\n",
+    "eph = obj.ephemerides()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac5fe7b5",
+   "metadata": {},
+   "source": [
+    "The columns we need are `RA`, `DEC`, the angular velocity components, and the visual\n",
+    "magnitude. Horizons returns `RA_rate` as the **on-sky** rate dα·cos(δ)/dt in arcsec/hour —\n",
+    "that is, the actual angular speed projected along the RA direction, not the raw\n",
+    "coordinate rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bcbf6f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u\n",
+    "\n",
+    "eph[\"datetime_str\", \"RA\", \"DEC\", \"RA_rate\", \"DEC_rate\", \"V\"].pprint()\n",
+    "\n",
+    "ra = eph[\"RA\"].value * u.deg\n",
+    "dec = eph[\"DEC\"].value * u.deg\n",
+    "ra_rate = eph[\"RA_rate\"].value * u.arcsec / u.hour  # on-sky: dα·cos(δ)/dt\n",
+    "dec_rate = eph[\"DEC_rate\"].value * u.arcsec / u.hour\n",
+    "visual_magnitude = eph[\"V\"].value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51bebeb4",
+   "metadata": {},
+   "source": [
+    "## 2. Create the moving source\n",
+    "\n",
+    "We wrap the asteroid into a `Sources` object. The flux is converted from visual magnitude\n",
+    "using an arbitrary zero-point of 22.5.\n",
+    "\n",
+    "`Sources.ra_rates` follows the same on-sky dα·cos(δ)/dt convention as Horizons, so we\n",
+    "can pass the rates directly — attaching astropy units lets cabaret convert from\n",
+    "arcsec/hour to the internal arcsec/s automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06de31df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cabaret\n",
+    "\n",
+    "asteroid = cabaret.Sources.from_arrays(\n",
+    "    ra=ra,\n",
+    "    dec=dec,\n",
+    "    fluxes=10 ** (-0.4 * (visual_magnitude - 22.5)),\n",
+    "    ra_rates=ra_rate,\n",
+    "    dec_rates=dec_rate,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e744c6c9",
+   "metadata": {},
+   "source": [
+    "## 3. Generate the simulated images\n",
+    "\n",
+    "For each exposure we:\n",
+    "\n",
+    "1. Point the telescope at the asteroid's current position (`ra[i]`, `dec[i]`).\n",
+    "2. Set `tracking_ra_rate` / `tracking_dec_rate` so the telescope follows the asteroid\n",
+    "   — stars therefore drift across the detector during the exposure.\n",
+    "3. Inject the asteroid as an `additional_sources` on top of the Gaia star field.\n",
+    "\n",
+    "The tracking rates use the same on-sky arcsec/s convention."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01e3885d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observatory = cabaret.Observatory()\n",
+    "\n",
+    "images = [\n",
+    "    observatory.generate_image(\n",
+    "        ra=ra[i],\n",
+    "        dec=dec[i],\n",
+    "        tracking_ra_rate=ra_rate[i],  # on-sky: dα·cos(δ)/dt\n",
+    "        tracking_dec_rate=dec_rate[i],\n",
+    "        exp_time=exposure_time,\n",
+    "        additional_sources=asteroid[i : i + 1],\n",
+    "    )\n",
+    "    for i in range(n_exposures)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9667fc62",
+   "metadata": {},
+   "source": [
+    "## 4. Inspect a single frame\n",
+    "\n",
+    "The asteroid should appear as a sharp point source at the image centre, while background\n",
+    "stars are smeared into short trails in the direction opposite to the asteroid's motion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad72fb02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cabaret.plot import plot_image\n",
+    "\n",
+    "_ = plot_image(images[0], title=\"Exposure 1 — asteroid at centre\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ace9db53",
+   "metadata": {},
+   "source": [
+    "## 5. Animate all exposures\n",
+    "\n",
+    "All frames share the same colour scale (1st–99.9th percentile across the whole stack) so\n",
+    "brightness is directly comparable between exposures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3e7d755",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from IPython.display import HTML\n",
+    "from matplotlib.animation import ArtistAnimation\n",
+    "\n",
+    "vmin, vmax = np.percentile(np.stack(images), [1, 99.9])\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 6))\n",
+    "fig.subplots_adjust(right=0.82)\n",
+    "plot_image(images[0], ax=ax, vmin=vmin, vmax=vmax)\n",
+    "\n",
+    "frames = []\n",
+    "for i, img in enumerate(images):\n",
+    "    im = ax.imshow(img, cmap=\"gray\", vmin=vmin, vmax=vmax, animated=True)\n",
+    "    label = ax.text(\n",
+    "        0.5,\n",
+    "        1.02,\n",
+    "        f\"Exposure {i + 1} of {n_exposures}\",\n",
+    "        transform=ax.transAxes,\n",
+    "        ha=\"center\",\n",
+    "        fontsize=12,\n",
+    "        fontweight=\"bold\",\n",
+    "    )\n",
+    "    frames.append([im, label])\n",
+    "\n",
+    "\n",
+    "ani = ArtistAnimation(fig, frames, interval=600, blit=True)\n",
+    "plt.close()\n",
+    "HTML(ani.to_jshtml())"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ name = "cabaret"
 readme = "README.md"
 repository = "https://github.com/ppp-one/cabaret"
 requires-python = ">=3.11"
-version = "0.5.0"
+version = "0.5.1"
 
 [project.optional-dependencies]
 plot = ["matplotlib"]

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 import numpy as np
@@ -13,10 +14,17 @@ from cabaret.camera import Camera
 from cabaret.focuser import Focuser
 from cabaret.queries import Filters, GaiaQuery, GaiaSQLiteSource, GaiaTAPSource
 from cabaret.site import Site
-from cabaret.sources import Sources, _normalize_rate
+from cabaret.sources import Sources
 from cabaret.telescope import Telescope
 
 logger = logging.getLogger("cabaret")
+
+
+def _normalize_rate(rate: float | u.Quantity) -> float:
+    """Convert a scalar angular rate to arcsec/s."""
+    if isinstance(rate, u.Quantity):
+        return float(rate.to(u.arcsec / u.s).value)
+    return float(rate)
 
 
 def moffat_profile(
@@ -171,7 +179,10 @@ def generate_star_image(
     drift_pixels: np.ndarray | None = None,
     n_trail_samples: int = 50,
     jitter_sigma_pixels: float = 0.0,
-    trail_sampler=None,
+    trail_sampler: Callable[
+        [float, float, float, float, int, float, np.random.Generator], np.ndarray
+    ]
+    | None = None,
 ) -> np.ndarray:
     """
     Render stars onto an image using a fast, windowed approach.
@@ -208,7 +219,6 @@ def generate_star_image(
     np.ndarray
         Image with rendered stars.
     """
-    # Validate inputs
     if not isinstance(n_trail_samples, int) or n_trail_samples < 1:
         raise ValueError(
             f"n_trail_samples must be an integer >= 1, got "
@@ -238,7 +248,7 @@ def generate_star_image(
 
     render_radius = FWHM * fwhm_multiplier  # render n * FWHM around the star
 
-    W, H = frame_size
+    frame_width, frame_height = frame_size
     image = np.zeros(frame_size).T
     for i, flux in enumerate(fluxes):
         x0 = pos[0][i]
@@ -251,9 +261,9 @@ def generate_star_image(
         # Skip if the entire trail bounding box is outside the frame
         if (
             max(x0, x_end) < 0
-            or min(x0, x_end) >= W
+            or min(x0, x_end) >= frame_width
             or max(y0, y_end) < 0
-            or min(y0, y_end) >= H
+            or min(y0, y_end) >= frame_height
         ):
             continue
 
@@ -282,10 +292,15 @@ def generate_star_image(
             for j in range(n_samples):
                 sx, sy = sample_pos[0, j], sample_pos[1, j]
                 sx_min = max(0, int(sx - render_radius))
-                sx_max = min(math.floor(sx + render_radius), W - 1)
+                sx_max = min(math.floor(sx + render_radius), frame_width - 1)
                 sy_min = max(0, int(sy - render_radius))
-                sy_max = min(math.floor(sy + render_radius), H - 1)
-                if sx_max < 0 or sx_min >= W or sy_max < 0 or sy_min >= H:
+                sy_max = min(math.floor(sy + render_radius), frame_height - 1)
+                if (
+                    sx_max < 0
+                    or sx_min >= frame_width
+                    or sy_max < 0
+                    or sy_min >= frame_height
+                ):
                     continue
                 image[sy_min : sy_max + 1, sx_min : sx_max + 1] += (
                     sample_flux
@@ -299,9 +314,9 @@ def generate_star_image(
                 )
         else:
             x_min = max(0, int(x0 - render_radius))
-            x_max = min(math.floor(x0 + render_radius), W - 1)
+            x_max = min(math.floor(x0 + render_radius), frame_width - 1)
             y_min = max(0, int(y0 - render_radius))
-            y_max = min(math.floor(y0 + render_radius), H - 1)
+            y_max = min(math.floor(y0 + render_radius), frame_height - 1)
 
             star = star_flux * moffat_profile(
                 xx[y_min : y_max + 1, x_min : x_max + 1],

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import UTC, datetime
 
 import numpy as np
@@ -281,9 +282,9 @@ def generate_star_image(
             for j in range(n_samples):
                 sx, sy = sample_pos[0, j], sample_pos[1, j]
                 sx_min = max(0, int(sx - render_radius))
-                sx_max = min(int(sx + render_radius), W - 1)
+                sx_max = min(math.floor(sx + render_radius), W - 1)
                 sy_min = max(0, int(sy - render_radius))
-                sy_max = min(int(sy + render_radius), H - 1)
+                sy_max = min(math.floor(sy + render_radius), H - 1)
                 if sx_max < 0 or sx_min >= W or sy_max < 0 or sy_min >= H:
                     continue
                 image[sy_min : sy_max + 1, sx_min : sx_max + 1] += (
@@ -298,9 +299,9 @@ def generate_star_image(
                 )
         else:
             x_min = max(0, int(x0 - render_radius))
-            x_max = min(int(x0 + render_radius), W - 1)
+            x_max = min(math.floor(x0 + render_radius), W - 1)
             y_min = max(0, int(y0 - render_radius))
-            y_max = min(int(y0 + render_radius), H - 1)
+            y_max = min(math.floor(y0 + render_radius), H - 1)
 
             star = star_flux * moffat_profile(
                 xx[y_min : y_max + 1, x_min : x_max + 1],
@@ -489,14 +490,12 @@ def add_stars(
 
         start_pixel = sources.to_pixel(wcs)
 
-        # rates are on-sky arcsec/s (dα·cosδ/dt), so convert to RA degrees via cosδ
+        # rates are on-sky arcsec/s (dα·cosδ/dt); spherical_offsets_by handles cosδ
         rel_ra_arcsec = (sources.ra_rates - tracking_ra_rate) * exp_time
         rel_dec_arcsec = (sources.dec_rates - tracking_dec_rate) * exp_time
-        cos_dec = np.cos(np.deg2rad(sources.coords.dec.deg))
-        end_coords = SkyCoord(
-            ra=sources.coords.ra.deg + rel_ra_arcsec / (3600.0 * cos_dec),
-            dec=sources.coords.dec.deg + rel_dec_arcsec / 3600.0,
-            unit="deg",
+        end_coords = sources.coords.spherical_offsets_by(
+            rel_ra_arcsec * u.arcsec,
+            rel_dec_arcsec * u.arcsec,
         )
         end_pixel = np.array(end_coords.to_pixel(wcs))
         drift_pixels = end_pixel - start_pixel

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -12,7 +12,7 @@ from cabaret.camera import Camera
 from cabaret.focuser import Focuser
 from cabaret.queries import Filters, GaiaQuery, GaiaSQLiteSource, GaiaTAPSource
 from cabaret.site import Site
-from cabaret.sources import Sources
+from cabaret.sources import Sources, _normalize_rate
 from cabaret.telescope import Telescope
 
 logger = logging.getLogger("cabaret")
@@ -111,6 +111,51 @@ def scintillation_noise(
     )
 
 
+def _sample_trail(
+    x0: float,
+    y0: float,
+    dx_pixel: float,
+    dy_pixel: float,
+    n_samples: int,
+    jitter_sigma_pixels: float,
+    rng: numpy.random.Generator,
+) -> np.ndarray:
+    """Sample n_samples positions uniformly along a linear drift trail.
+
+    The trail runs from (x0, y0) at the start of the exposure to
+    (x0 + dx_pixel, y0 + dy_pixel) at the end.
+
+    To implement non-linear (ephemeris-based) motion, provide a callable with
+    this same signature as the ``trail_sampler`` argument of
+    ``generate_star_image``.
+
+    Parameters
+    ----------
+    x0, y0 : float
+        Pixel position at the start of the exposure (t=0).
+    dx_pixel, dy_pixel : float
+        Total pixel displacement over the full exposure duration.
+    n_samples : int
+        Number of sample positions along the trail.
+    jitter_sigma_pixels : float
+        1-sigma Gaussian jitter applied independently to each sample (pixels).
+    rng : numpy.random.Generator
+        Random number generator for jitter.
+
+    Returns
+    -------
+    np.ndarray
+        Shape (2, n_samples): row 0 is x positions, row 1 is y positions.
+    """
+    t = np.linspace(0.0, 1.0, n_samples)
+    xs = x0 + t * dx_pixel
+    ys = y0 + t * dy_pixel
+    if jitter_sigma_pixels > 0.0:
+        xs += rng.normal(0.0, jitter_sigma_pixels, n_samples)
+        ys += rng.normal(0.0, jitter_sigma_pixels, n_samples)
+    return np.stack([xs, ys])
+
+
 def generate_star_image(
     pos: np.ndarray,
     fluxes: list[float],
@@ -122,6 +167,10 @@ def generate_star_image(
     exp_time: float,
     airmass: float = 1.5,
     fwhm_multiplier: float = 5.0,
+    drift_pixels: np.ndarray | None = None,
+    n_trail_samples: int = 50,
+    jitter_sigma_pixels: float = 0.0,
+    trail_sampler=None,
 ) -> np.ndarray:
     """
     Render stars onto an image using a fast, windowed approach.
@@ -129,7 +178,7 @@ def generate_star_image(
     Parameters
     ----------
     pos : np.ndarray
-        Pixel positions of stars (shape: 2, n_stars).
+        Pixel positions of stars at the start of the exposure (shape: 2, n_stars).
     fluxes : list
         list of fluxes for each star.
     FWHM : float
@@ -140,29 +189,72 @@ def generate_star_image(
         Random number generator for Poisson noise.
     fwhm_multiplier : float, optional
         Multiplier to determine the rendering radius around each star (default: 5.0).
+    drift_pixels : np.ndarray, optional
+        Total pixel displacement over the exposure for each star (shape: 2, n_stars).
+        Row 0 is x-drift, row 1 is y-drift. None means no drift (point PSF).
+    n_trail_samples : int, optional
+        Maximum number of Moffat samples along the drift trail (default: 50).
+        The actual count is adaptive: ``max(1, ceil(trail_length_px / FWHM * 2))``,
+        capped at this value.
+    jitter_sigma_pixels : float, optional
+        1-sigma guiding jitter added independently to each trail sample (pixels).
+    trail_sampler : callable, optional
+        Function with the same signature as ``_sample_trail`` for non-linear motion.
+        Defaults to ``_sample_trail`` (linear interpolation).
 
     Returns
     -------
     np.ndarray
         Image with rendered stars.
     """
+    # Validate inputs
+    if not isinstance(n_trail_samples, int) or n_trail_samples < 1:
+        raise ValueError(
+            f"n_trail_samples must be an integer >= 1, got "
+            f"{n_trail_samples} ({type(n_trail_samples).__name__})"
+        )
+
+    if jitter_sigma_pixels < 0:
+        raise ValueError(f"jitter_sigma_pixels must be >= 0, got {jitter_sigma_pixels}")
+
+    n_stars = len(fluxes)
+
+    if drift_pixels is None:
+        _drift = np.zeros((2, n_stars), dtype=np.float64)
+    else:
+        _drift = np.asarray(drift_pixels, dtype=np.float64)
+        if _drift.ndim != 2 or _drift.shape != (2, n_stars):
+            raise ValueError(
+                "drift_pixels must have shape (2, n_stars) "
+                f"where n_stars={n_stars}; got shape {_drift.shape}"
+            )
+    has_drift = (_drift[0] != 0.0) | (_drift[1] != 0.0)
+    _sampler = trail_sampler if trail_sampler is not None else _sample_trail
+
     x = np.linspace(0, frame_size[0] - 1, frame_size[0])
     y = np.linspace(0, frame_size[1] - 1, frame_size[1])
     xx, yy = np.meshgrid(x, y)
 
     render_radius = FWHM * fwhm_multiplier  # render n * FWHM around the star
 
+    W, H = frame_size
     image = np.zeros(frame_size).T
     for i, flux in enumerate(fluxes):
         x0 = pos[0][i]
         y0 = pos[1][i]
-        if x0 < 0 or x0 >= frame_size[0] or y0 < 0 or y0 >= frame_size[1]:
-            # print(f"Star {i} is outside the frame.")
+        dx = _drift[0, i]
+        dy = _drift[1, i]
+        x_end = x0 + dx
+        y_end = y0 + dy
+
+        # Skip if the entire trail bounding box is outside the frame
+        if (
+            max(x0, x_end) < 0
+            or min(x0, x_end) >= W
+            or max(y0, y_end) < 0
+            or min(y0, y_end) >= H
+        ):
             continue
-        x_min, x_max = int(x0 - render_radius), int(x0 + render_radius)
-        y_min, y_max = int(y0 - render_radius), int(y0 + render_radius)
-        x_min, x_max = max(0, x_min), min(x_max, frame_size[0] - 1)
-        y_min, y_max = max(0, y_min), min(y_max, frame_size[1] - 1)
 
         scint_noise = scintillation_noise(
             r=telescope_aperture / 2,
@@ -178,15 +270,47 @@ def generate_star_image(
         if star_flux < 0:
             star_flux = 0
 
-        star = star_flux * moffat_profile(
-            xx[y_min : y_max + 1, x_min : x_max + 1],
-            yy[y_min : y_max + 1, x_min : x_max + 1],
-            x0,
-            y0,
-            FWHM,
-        )
+        if has_drift[i]:
+            trail_length = np.hypot(dx, dy)
+            n_samples = max(
+                1, min(n_trail_samples, int(np.ceil(trail_length / FWHM * 2)))
+            )
 
-        image[y_min : y_max + 1, x_min : x_max + 1] += star
+            sample_pos = _sampler(x0, y0, dx, dy, n_samples, jitter_sigma_pixels, rng)
+            sample_flux = star_flux / sample_pos.shape[1]
+            for j in range(n_samples):
+                sx, sy = sample_pos[0, j], sample_pos[1, j]
+                sx_min = max(0, int(sx - render_radius))
+                sx_max = min(int(sx + render_radius), W - 1)
+                sy_min = max(0, int(sy - render_radius))
+                sy_max = min(int(sy + render_radius), H - 1)
+                if sx_max < 0 or sx_min >= W or sy_max < 0 or sy_min >= H:
+                    continue
+                image[sy_min : sy_max + 1, sx_min : sx_max + 1] += (
+                    sample_flux
+                    * moffat_profile(
+                        xx[sy_min : sy_max + 1, sx_min : sx_max + 1],
+                        yy[sy_min : sy_max + 1, sx_min : sx_max + 1],
+                        sx,
+                        sy,
+                        FWHM,
+                    )
+                )
+        else:
+            x_min = max(0, int(x0 - render_radius))
+            x_max = min(int(x0 + render_radius), W - 1)
+            y_min = max(0, int(y0 - render_radius))
+            y_max = min(int(y0 + render_radius), H - 1)
+
+            star = star_flux * moffat_profile(
+                xx[y_min : y_max + 1, x_min : x_max + 1],
+                yy[y_min : y_max + 1, x_min : x_max + 1],
+                x0,
+                y0,
+                FWHM,
+            )
+
+            image[y_min : y_max + 1, x_min : x_max + 1] += star
 
     return image
 
@@ -201,6 +325,7 @@ def get_sources(
     sources: Sources | None = None,
     tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
     bounds: tuple[float, float, float, float] | None = None,
+    additional_sources: Sources | None = None,
 ) -> Sources:
     """Get sources from Gaia or use provided sources."""
     if not isinstance(sources, Sources):
@@ -216,6 +341,8 @@ def get_sources(
             tap_source=tap_source,
         )
         logger.info(f"Found {len(sources)} sources (user set limit of {n_star_limit}).")
+    if additional_sources is not None:
+        sources = sources + additional_sources
     return sources
 
 
@@ -322,8 +449,29 @@ def add_stars(
     dateobs: datetime | None,
     airmass: float | None,
     fwhm_multiplier: float = 5.0,
+    tracking_ra_rate: float | u.Quantity = 0.0,
+    tracking_dec_rate: float | u.Quantity = 0.0,
+    n_trail_samples: int = 50,
+    jitter_sigma: float = 0.0,
 ) -> np.ndarray:
-    """Add stars to the image using the Moffat profile and sky background."""
+    """Add stars to the image using the Moffat profile and sky background.
+
+    Parameters
+    ----------
+    tracking_ra_rate : float or astropy Quantity, optional
+        Telescope RA tracking rate offset from sidereal in on-sky arcsec/s,
+        i.e. dα·cos(δ)/dt (default: 0). Accepts any astropy angular velocity
+        Quantity (e.g. ``1 * u.arcsec / u.s``).
+    tracking_dec_rate : float or astropy Quantity, optional
+        Telescope Dec tracking rate offset from sidereal in arcsec/s (default: 0).
+        Accepts any astropy angular velocity Quantity.
+    n_trail_samples : int, optional
+        Number of PSF samples along the drift trail for moving sources (default: 50).
+    jitter_sigma : float, optional
+        1-sigma guiding jitter in arcsec applied per trail sample (default: 0).
+    """
+    tracking_ra_rate = _normalize_rate(tracking_ra_rate)
+    tracking_dec_rate = _normalize_rate(tracking_dec_rate)
     sources = sources.drop_nan_fluxes()
     if len(sources) > 0:
         fluxes = (
@@ -338,10 +486,29 @@ def add_stars(
 
         if wcs is None:
             wcs = camera.get_wcs(SkyCoord(ra=ra, dec=dec, unit="deg"))
-        gaias_pixel = sources.to_pixel(wcs)
-        on_camera_mask = camera.on_camera_mask(gaias_pixel)
+
+        start_pixel = sources.to_pixel(wcs)
+
+        # rates are on-sky arcsec/s (dα·cosδ/dt), so convert to RA degrees via cosδ
+        rel_ra_arcsec = (sources.ra_rates - tracking_ra_rate) * exp_time
+        rel_dec_arcsec = (sources.dec_rates - tracking_dec_rate) * exp_time
+        cos_dec = np.cos(np.deg2rad(sources.coords.dec.deg))
+        end_coords = SkyCoord(
+            ra=sources.coords.ra.deg + rel_ra_arcsec / (3600.0 * cos_dec),
+            dec=sources.coords.dec.deg + rel_dec_arcsec / 3600.0,
+            unit="deg",
+        )
+        end_pixel = np.array(end_coords.to_pixel(wcs))
+        drift_pixels = end_pixel - start_pixel
+
+        on_camera_mask = (
+            (np.maximum(start_pixel[0], end_pixel[0]) >= 0)
+            & (np.minimum(start_pixel[0], end_pixel[0]) < camera.width)
+            & (np.maximum(start_pixel[1], end_pixel[1]) >= 0)
+            & (np.minimum(start_pixel[1], end_pixel[1]) < camera.height)
+        )
         logger.debug(
-            f"Number of stars on camera: {on_camera_mask.sum()}"
+            f"Number of stars with trails intersecting camera: {on_camera_mask.sum()}"
             f" out of {len(sources)} total stars "
             f"({on_camera_mask.sum() / len(sources) * 100})%."
         )
@@ -369,7 +536,7 @@ def add_stars(
             airmass = 1.5  # default value
 
         stars = generate_star_image(
-            gaias_pixel[:, on_camera_mask],
+            start_pixel[:, on_camera_mask],
             fluxes[on_camera_mask],
             focuser.seeing_multiplier * site.seeing / camera.plate_scale,
             (camera.width, camera.height),
@@ -379,6 +546,9 @@ def add_stars(
             exp_time=exp_time,
             airmass=airmass,
             fwhm_multiplier=fwhm_multiplier,
+            drift_pixels=drift_pixels[:, on_camera_mask],
+            n_trail_samples=n_trail_samples,
+            jitter_sigma_pixels=jitter_sigma / camera.plate_scale,
         ).astype(np.float64)
 
         sky_background = (
@@ -415,6 +585,11 @@ def add_stars_and_sky(
     wcs: WCS | None,
     fwhm_multiplier: float = 5.0,
     tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+    tracking_ra_rate: float | u.Quantity = 0.0,
+    tracking_dec_rate: float | u.Quantity = 0.0,
+    n_trail_samples: int = 50,
+    jitter_sigma: float = 0.0,
+    additional_sources: Sources | None = None,
 ) -> np.ndarray:
     """Add stars and sky background to the base image."""
     if light == 1:
@@ -438,6 +613,7 @@ def add_stars_and_sky(
             timeout=timeout,
             sources=sources,
             tap_source=tap_source,
+            additional_sources=additional_sources,
         )
         image = base
         image = add_sun_sky_background(
@@ -458,6 +634,10 @@ def add_stars_and_sky(
             dateobs=dateobs,
             airmass=airmass,
             fwhm_multiplier=fwhm_multiplier,
+            tracking_ra_rate=tracking_ra_rate,
+            tracking_dec_rate=tracking_dec_rate,
+            n_trail_samples=n_trail_samples,
+            jitter_sigma=jitter_sigma,
         )
     else:
         image = base
@@ -484,6 +664,11 @@ def generate_image(
     wcs: WCS | None = None,
     fwhm_multiplier: float = 5.0,
     tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+    tracking_ra_rate: float | u.Quantity = 0.0,
+    tracking_dec_rate: float | u.Quantity = 0.0,
+    n_trail_samples: int = 50,
+    jitter_sigma: float = 0.0,
+    additional_sources: Sources | None = None,
 ) -> np.ndarray:
     """
     Generate a simulated astronomical image.
@@ -561,6 +746,11 @@ def generate_image(
             wcs=wcs,
             fwhm_multiplier=fwhm_multiplier,
             tap_source=tap_source,
+            tracking_ra_rate=tracking_ra_rate,
+            tracking_dec_rate=tracking_dec_rate,
+            n_trail_samples=n_trail_samples,
+            jitter_sigma=jitter_sigma,
+            additional_sources=additional_sources,
         )
     else:
         image = base
@@ -595,6 +785,11 @@ def generate_image_stack(
     wcs: WCS | None = None,
     fwhm_multiplier: float = 5.0,
     tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+    tracking_ra_rate: float | u.Quantity = 0.0,
+    tracking_dec_rate: float | u.Quantity = 0.0,
+    n_trail_samples: int = 50,
+    jitter_sigma: float = 0.0,
+    additional_sources: Sources | None = None,
 ) -> np.ndarray:
     """
     Generate a stack of images from different stages in the image simulation pipeline.
@@ -678,6 +873,11 @@ def generate_image_stack(
             wcs=wcs,
             fwhm_multiplier=fwhm_multiplier,
             tap_source=tap_source,
+            tracking_ra_rate=tracking_ra_rate,
+            tracking_dec_rate=tracking_dec_rate,
+            n_trail_samples=n_trail_samples,
+            jitter_sigma=jitter_sigma,
+            additional_sources=additional_sources,
         )
     else:
         image = base

--- a/src/cabaret/observatory.py
+++ b/src/cabaret/observatory.py
@@ -181,9 +181,9 @@ class Observatory:
             exposure when simulating star trails. Larger values give smoother
             trails at higher computational cost.
         jitter_sigma : float, optional
-            Standard deviation of pointing jitter applied during rendering, in
-            the units expected by ``generate_image``. Larger values produce
-            broader motion blur from random tracking variations.
+            1-sigma guiding jitter in arcsec applied per trail sample
+            (default: 0). Larger values produce broader motion blur from
+            random tracking variations.
         additional_sources : Sources, optional
             Additional ``Sources`` to render in every image on top of the base
             source set. When supplied, they are appended to the sources obtained
@@ -304,9 +304,9 @@ class Observatory:
             exposure when simulating star trails. Larger values give smoother
             trails at higher computational cost.
         jitter_sigma : float, optional
-            Standard deviation of pointing jitter applied during rendering, in
-            the units expected by ``generate_image``. Larger values produce
-            broader motion blur from random tracking variations.
+            1-sigma guiding jitter in arcsec applied per trail sample
+            (default: 0). Larger values produce broader motion blur from
+            random tracking variations.
         additional_sources : Sources, optional
             Additional ``Sources`` to render in every image on top of the base
             source set. When supplied, they are appended to the sources obtained
@@ -428,9 +428,9 @@ class Observatory:
             exposure when simulating star trails. Larger values give smoother
             trails at higher computational cost.
         jitter_sigma : float, optional
-            Standard deviation of pointing jitter applied during rendering, in
-            the units expected by ``generate_image``. Larger values produce
-            broader motion blur from random tracking variations.
+            1-sigma guiding jitter in arcsec applied per trail sample
+            (default: 0). Larger values produce broader motion blur from
+            random tracking variations.
         additional_sources : Sources, optional
             Additional ``Sources`` to render in every image on top of the base
             source set. When supplied, they are appended to the sources obtained

--- a/src/cabaret/observatory.py
+++ b/src/cabaret/observatory.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy.random
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.wcs import WCS
@@ -126,6 +127,11 @@ class Observatory:
         wcs: WCS | None = None,
         fwhm_multiplier: float = 5.0,
         tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+        tracking_ra_rate: float | u.Quantity = 0.0,
+        tracking_dec_rate: float | u.Quantity = 0.0,
+        n_trail_samples: int = 50,
+        jitter_sigma: float = 0.0,
+        additional_sources: Sources | None = None,
     ) -> numpy.ndarray:
         """Generate a simulated image of the sky.
 
@@ -140,7 +146,7 @@ class Observatory:
         dateobs : datetime, optional
             Observation date and time in UTC.
         light : int, optional
-
+            If 1, simulate light exposure; if 0, simulate dark exposure.
         filter_band : Filters or str, optional
             Photometric filter to use for the simulation (default: Filters.G).
         airmass : float, optional
@@ -162,6 +168,27 @@ class Observatory:
         fwhm_multiplier : float, optional
             Multiplier to determine the rendering radius around each star
             (default: 5.0).
+        tracking_ra_rate : float, u.Quantity, optional
+            Telescope tracking rate offset in right ascension, in angular sky
+            coordinate units per second as expected by ``generate_image``.
+            Non-zero values simulate RA drift/trailing during the exposure.
+        tracking_dec_rate : float, u.Quantity, optional
+            Telescope tracking rate offset in declination, in angular sky
+            coordinate units per second as expected by ``generate_image``.
+            Non-zero values simulate Dec drift/trailing during the exposure.
+        n_trail_samples : int, optional
+            Number of samples used to integrate source motion across the
+            exposure when simulating star trails. Larger values give smoother
+            trails at higher computational cost.
+        jitter_sigma : float, optional
+            Standard deviation of pointing jitter applied during rendering, in
+            the units expected by ``generate_image``. Larger values produce
+            broader motion blur from random tracking variations.
+        additional_sources : Sources, optional
+            Additional ``Sources`` to render in every image on top of the base
+            source set. When supplied, they are appended to the sources obtained
+            from Gaia, or to the explicitly provided ``sources`` collection;
+            they do not replace those base sources.
         """
         return generate_image(
             ra=ra,
@@ -183,6 +210,11 @@ class Observatory:
             wcs=wcs,
             fwhm_multiplier=fwhm_multiplier,
             tap_source=tap_source,
+            tracking_ra_rate=tracking_ra_rate,
+            tracking_dec_rate=tracking_dec_rate,
+            n_trail_samples=n_trail_samples,
+            jitter_sigma=jitter_sigma,
+            additional_sources=additional_sources,
         )
 
     def generate_image_stack(
@@ -203,6 +235,11 @@ class Observatory:
         wcs: WCS | None = None,
         fwhm_multiplier: float = 5.0,
         tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+        tracking_ra_rate: float | u.Quantity = 0.0,
+        tracking_dec_rate: float | u.Quantity = 0.0,
+        n_trail_samples: int = 50,
+        jitter_sigma: float = 0.0,
+        additional_sources: Sources | None = None,
     ) -> numpy.ndarray:
         """
         Generate a stack of images from different stages in the image simulation
@@ -254,6 +291,27 @@ class Observatory:
         fwhm_multiplier : float, optional
             Multiplier to determine the rendering radius around each star
             (default: 5.0).
+        tracking_ra_rate : float, u.Quantity, optional
+            Telescope tracking rate offset in right ascension, in angular sky
+            coordinate units per second as expected by ``generate_image``.
+            Non-zero values simulate RA drift/trailing during the exposure.
+        tracking_dec_rate : float, u.Quantity, optional
+            Telescope tracking rate offset in declination, in angular sky
+            coordinate units per second as expected by ``generate_image``.
+            Non-zero values simulate Dec drift/trailing during the exposure.
+        n_trail_samples : int, optional
+            Number of samples used to integrate source motion across the
+            exposure when simulating star trails. Larger values give smoother
+            trails at higher computational cost.
+        jitter_sigma : float, optional
+            Standard deviation of pointing jitter applied during rendering, in
+            the units expected by ``generate_image``. Larger values produce
+            broader motion blur from random tracking variations.
+        additional_sources : Sources, optional
+            Additional ``Sources`` to render in every image on top of the base
+            source set. When supplied, they are appended to the sources obtained
+            from Gaia, or to the explicitly provided ``sources`` collection;
+            they do not replace those base sources.
 
         Returns
         -------
@@ -285,6 +343,11 @@ class Observatory:
             wcs=wcs,
             fwhm_multiplier=fwhm_multiplier,
             tap_source=tap_source,
+            tracking_ra_rate=tracking_ra_rate,
+            tracking_dec_rate=tracking_dec_rate,
+            n_trail_samples=n_trail_samples,
+            jitter_sigma=jitter_sigma,
+            additional_sources=additional_sources,
         )
 
     def generate_fits_image(
@@ -305,8 +368,13 @@ class Observatory:
         wcs: WCS | None = None,
         fwhm_multiplier: float = 5.0,
         user_header: dict[str, Any] | fits.Header | None = None,
-        overwrite: bool = True,
         tap_source: GaiaTAPSource | GaiaSQLiteSource | str | None = None,
+        tracking_ra_rate: float | u.Quantity = 0.0,
+        tracking_dec_rate: float | u.Quantity = 0.0,
+        n_trail_samples: int = 50,
+        jitter_sigma: float = 0.0,
+        additional_sources: Sources | None = None,
+        overwrite: bool = True,
     ) -> fits.HDUList:
         """Generate a simulated FITS image of the sky.
 
@@ -347,6 +415,27 @@ class Observatory:
         fwhm_multiplier : float, optional
             Multiplier to determine the rendering radius around each star
             (default: 5.0).
+        tracking_ra_rate : float, u.Quantity, optional
+            Telescope tracking rate offset in right ascension, in angular sky
+            coordinate units per second as expected by ``generate_image``.
+            Non-zero values simulate RA drift/trailing during the exposure.
+        tracking_dec_rate : float, u.Quantity, optional
+            Telescope tracking rate offset in declination, in angular sky
+            coordinate units per second as expected by ``generate_image``.
+            Non-zero values simulate Dec drift/trailing during the exposure.
+        n_trail_samples : int, optional
+            Number of samples used to integrate source motion across the
+            exposure when simulating star trails. Larger values give smoother
+            trails at higher computational cost.
+        jitter_sigma : float, optional
+            Standard deviation of pointing jitter applied during rendering, in
+            the units expected by ``generate_image``. Larger values produce
+            broader motion blur from random tracking variations.
+        additional_sources : Sources, optional
+            Additional ``Sources`` to render in every image on top of the base
+            source set. When supplied, they are appended to the sources obtained
+            from Gaia, or to the explicitly provided ``sources`` collection;
+            they do not replace those base sources.
         overwrite : bool, optional
             Whether to overwrite existing file (default: True).
 
@@ -375,6 +464,11 @@ class Observatory:
             wcs=wcs,
             fwhm_multiplier=fwhm_multiplier,
             tap_source=tap_source,
+            tracking_ra_rate=tracking_ra_rate,
+            tracking_dec_rate=tracking_dec_rate,
+            n_trail_samples=n_trail_samples,
+            jitter_sigma=jitter_sigma,
+            additional_sources=additional_sources,
         )
 
         if wcs is None:

--- a/src/cabaret/plot.py
+++ b/src/cabaret/plot.py
@@ -17,6 +17,8 @@ def plot_image(
     colorbar_kwargs={},
     transparent=True,
     contrast=0.25,
+    vmin=None,
+    vmax=None,
 ):
     """Plot a 2D image with zscale normalization.
 
@@ -36,13 +38,20 @@ def plot_image(
         Additional kwargs for colorbar.
     transparent : bool, optional
         If True, set figure background to transparent.
+    vmin, vmax : float, optional
+        Color scale limits. If not provided, computed via ZScale.
     """
     if ax is None:
         fig, ax = plt.subplots(figsize=(8, 8))
     else:
         fig = plt.gcf()
-    interval = ZScaleInterval(contrast=contrast)
-    vmin, vmax = interval.get_limits(image)
+    if vmin is None or vmax is None:
+        interval = ZScaleInterval(contrast=contrast)
+        zmin, zmax = interval.get_limits(image)
+        if vmin is None:
+            vmin = zmin
+        if vmax is None:
+            vmax = zmax
     img = ax.imshow(image, vmin=vmin, vmax=vmax, cmap=cmap, rasterized=True)
     if title is not None:
         ax.set_title(title)

--- a/src/cabaret/sources.py
+++ b/src/cabaret/sources.py
@@ -1,8 +1,30 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
+from astropy import units as u
 from astropy.coordinates import Longitude, SkyCoord
 from astropy.wcs import WCS
+
+
+def _normalize_rates(
+    rates: np.ndarray | u.Quantity | None, n: int, name: str
+) -> np.ndarray:
+    """Convert rates to a plain arcsec/s numpy array of shape (n,)."""
+    if rates is None:
+        return np.zeros(n, dtype=np.float64)
+    if isinstance(rates, u.Quantity):
+        rates = rates.to(u.arcsec / u.s).value
+    rates = np.asarray(rates, dtype=np.float64)
+    if rates.shape != (n,):
+        raise ValueError(f"{name} must have shape ({n},).")
+    return rates
+
+
+def _normalize_rate(rate: float | u.Quantity) -> float:
+    """Convert a scalar rate to arcsec/s."""
+    if isinstance(rate, u.Quantity):
+        return float(rate.to(u.arcsec / u.s).value)
+    return float(rate)
 
 
 @dataclass
@@ -31,6 +53,15 @@ class Sources:
     fluxes: np.ndarray
     """An array of shape (n,) containing the fluxes of the sources in units of
     photons/s/m²."""
+    ra_rates: np.ndarray | u.Quantity | None = field(default=None, repr=False)
+    """On-sky RA motion rates dα·cos(δ)/dt, shape (n,). Accepts an astropy
+    Quantity with angular velocity units (e.g. ``u.arcsec/u.hour``) or a plain
+    array assumed to be in arcsec/s. Stored internally as arcsec/s. Positive
+    values move east. This matches the JPL Horizons ``RA_rate`` convention."""
+    dec_rates: np.ndarray | u.Quantity | None = field(default=None, repr=False)
+    """Dec motion rates, shape (n,). Accepts an astropy Quantity with angular
+    velocity units or a plain array assumed to be in arcsec/s. Stored
+    internally as arcsec/s. Positive values move north."""
 
     def __post_init__(self):
         if not isinstance(self.coords, SkyCoord):
@@ -42,6 +73,10 @@ class Sources:
                 raise ValueError("fluxes must be an instance of np.ndarray.")
         if self.coords.size != self.fluxes.size:
             raise ValueError("coords and fluxes must have the same length.")
+
+        n = self.coords.size
+        self.ra_rates = _normalize_rates(self.ra_rates, n, "ra_rates")
+        self.dec_rates = _normalize_rates(self.dec_rates, n, "dec_rates")
 
     @property
     def ra(self) -> Longitude:
@@ -90,12 +125,46 @@ class Sources:
 
     def __getitem__(self, key) -> "Sources":
         new_fluxes = np.asarray(self.fluxes)[key]
+        new_ra_rates = np.asarray(self.ra_rates)[key]
+        new_dec_rates = np.asarray(self.dec_rates)[key]
         if np.isscalar(new_fluxes):
             new_fluxes = np.array([new_fluxes])
+            new_ra_rates = np.array([new_ra_rates])
+            new_dec_rates = np.array([new_dec_rates])
 
         new_coords = self.coords[key]
 
-        return Sources(new_coords, new_fluxes)  # type: ignore
+        return Sources(new_coords, new_fluxes, new_ra_rates, new_dec_rates)  # type: ignore
+
+    def __add__(self, other: "Sources") -> "Sources":
+        return Sources.concat(self, other)
+
+    @classmethod
+    def concat(cls, *sources_list: "Sources") -> "Sources":
+        """Concatenate multiple Sources objects into one.
+
+        Parameters
+        ----------
+        *sources_list : Sources
+            Two or more Sources objects to concatenate.
+
+        Returns
+        -------
+        Sources
+            A new Sources instance with all sources combined.
+        """
+        if not sources_list:
+            raise ValueError("Must provide at least one Sources object to concatenate.")
+        return cls(
+            coords=SkyCoord(
+                ra=np.concatenate([s.coords.ra.deg for s in sources_list]),  # type: ignore
+                dec=np.concatenate([s.coords.dec.deg for s in sources_list]),  # type: ignore
+                unit="deg",
+            ),
+            fluxes=np.concatenate([s.fluxes for s in sources_list]),
+            ra_rates=np.concatenate([s.ra_rates for s in sources_list]),  # type: ignore
+            dec_rates=np.concatenate([s.dec_rates for s in sources_list]),  # type: ignore
+        )
 
     @classmethod
     def from_arrays(
@@ -104,6 +173,8 @@ class Sources:
         dec: np.ndarray | list,
         fluxes: np.ndarray | list,
         units: str = "deg",
+        ra_rates: np.ndarray | list | None = None,
+        dec_rates: np.ndarray | list | None = None,
     ) -> "Sources":
         """Create a Sources instance from separate RA and DEC arrays.
 
@@ -116,8 +187,12 @@ class Sources:
         fluxes : np.ndarray
             An array of shape (n,) containing the fluxes of the sources.
             These should be of units photons/s/m².
-        **kwargs
-            Additional keyword arguments passed to the Sources constructor.
+        units : str, optional
+            Units for ra and dec, by default "deg".
+        ra_rates : np.ndarray or list, optional
+            RA motion rates in arcsec/s, shape (n,). Defaults to zeros.
+        dec_rates : np.ndarray or list, optional
+            Dec motion rates in arcsec/s, shape (n,). Defaults to zeros.
 
         Returns
         -------
@@ -136,12 +211,20 @@ class Sources:
                 raise ValueError("dec must be an instance of np.ndarray.")
         if ra.shape != dec.shape:
             raise ValueError("ra and dec must have the same shape.")
+        if not isinstance(fluxes, np.ndarray):
+            try:
+                fluxes = np.array(fluxes)
+            except Exception:
+                raise ValueError("fluxes must be an instance of np.ndarray.")
+        if not (ra.shape == fluxes.shape):
+            raise ValueError("ra, dec, and fluxes must all have the same shape.")
 
-        parameters = {
-            "coords": SkyCoord(ra=ra, dec=dec, unit=units),
-            "fluxes": fluxes,
-        }
-        return cls(**(parameters))
+        return cls(
+            coords=SkyCoord(ra=ra, dec=dec, unit=units),
+            fluxes=fluxes,
+            ra_rates=ra_rates,  # type: ignore
+            dec_rates=dec_rates,  # type: ignore
+        )
 
     def drop_nan_fluxes(self) -> "Sources":
         """Return a new Sources instance with any sources that have NaN fluxes removed.

--- a/src/cabaret/sources.py
+++ b/src/cabaret/sources.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import Longitude, SkyCoord
+from astropy.coordinates import Longitude, SkyCoord, concatenate
 from astropy.wcs import WCS
 
 
@@ -156,11 +156,7 @@ class Sources:
         if not sources_list:
             raise ValueError("Must provide at least one Sources object to concatenate.")
         return cls(
-            coords=SkyCoord(
-                ra=np.concatenate([s.coords.ra.deg for s in sources_list]),  # type: ignore
-                dec=np.concatenate([s.coords.dec.deg for s in sources_list]),  # type: ignore
-                unit="deg",
-            ),
+            coords=concatenate([s.coords for s in sources_list]),
             fluxes=np.concatenate([s.fluxes for s in sources_list]),
             ra_rates=np.concatenate([s.ra_rates for s in sources_list]),  # type: ignore
             dec_rates=np.concatenate([s.dec_rates for s in sources_list]),  # type: ignore

--- a/src/cabaret/sources.py
+++ b/src/cabaret/sources.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import Longitude, SkyCoord, concatenate
+from astropy.coordinates import Longitude, SkyCoord
 from astropy.wcs import WCS
 
 
@@ -20,14 +20,7 @@ def _normalize_rates(
     return rates
 
 
-def _normalize_rate(rate: float | u.Quantity) -> float:
-    """Convert a scalar rate to arcsec/s."""
-    if isinstance(rate, u.Quantity):
-        return float(rate.to(u.arcsec / u.s).value)
-    return float(rate)
-
-
-@dataclass
+@dataclass(init=False)
 class Sources:
     """A collection of sources with their sky coordinates and fluxes.
 
@@ -53,30 +46,38 @@ class Sources:
     fluxes: np.ndarray
     """An array of shape (n,) containing the fluxes of the sources in units of
     photons/s/m²."""
-    ra_rates: np.ndarray | u.Quantity | None = field(default=None, repr=False)
-    """On-sky RA motion rates dα·cos(δ)/dt, shape (n,). Accepts an astropy
-    Quantity with angular velocity units (e.g. ``u.arcsec/u.hour``) or a plain
-    array assumed to be in arcsec/s. Stored internally as arcsec/s. Positive
+    ra_rates: np.ndarray = field(init=False, repr=False)
+    """On-sky RA motion rates dα·cos(δ)/dt, shape (n,) in arcsec/s. Accepts an
+    astropy Quantity with angular velocity units (e.g. ``u.arcsec/u.hour``) or a
+    plain array assumed to be in arcsec/s. Stored internally as arcsec/s. Positive
     values move east. This matches the JPL Horizons ``RA_rate`` convention."""
-    dec_rates: np.ndarray | u.Quantity | None = field(default=None, repr=False)
-    """Dec motion rates, shape (n,). Accepts an astropy Quantity with angular
-    velocity units or a plain array assumed to be in arcsec/s. Stored
+    dec_rates: np.ndarray = field(init=False, repr=False)
+    """Dec motion rates, shape (n,) in arcsec/s. Accepts an astropy Quantity with
+    angular velocity units or a plain array assumed to be in arcsec/s. Stored
     internally as arcsec/s. Positive values move north."""
 
-    def __post_init__(self):
-        if not isinstance(self.coords, SkyCoord):
+    def __init__(
+        self,
+        coords: SkyCoord,
+        fluxes: np.ndarray,
+        ra_rates: np.ndarray | u.Quantity | None = None,
+        dec_rates: np.ndarray | u.Quantity | None = None,
+    ) -> None:
+        if not isinstance(coords, SkyCoord):
             raise ValueError("coords must be an instance of SkyCoord.")
-        if not isinstance(self.fluxes, np.ndarray):
+        if not isinstance(fluxes, np.ndarray):
             try:
-                self.fluxes = np.array(self.fluxes)
+                fluxes = np.array(fluxes)
             except Exception:
                 raise ValueError("fluxes must be an instance of np.ndarray.")
-        if self.coords.size != self.fluxes.size:
+        if coords.size != fluxes.size:
             raise ValueError("coords and fluxes must have the same length.")
 
-        n = self.coords.size
-        self.ra_rates = _normalize_rates(self.ra_rates, n, "ra_rates")
-        self.dec_rates = _normalize_rates(self.dec_rates, n, "dec_rates")
+        self.coords = coords
+        self.fluxes = fluxes
+        n = coords.size
+        self.ra_rates = _normalize_rates(ra_rates, n, "ra_rates")
+        self.dec_rates = _normalize_rates(dec_rates, n, "dec_rates")
 
     @property
     def ra(self) -> Longitude:
@@ -134,7 +135,7 @@ class Sources:
 
         new_coords = self.coords[key]
 
-        return Sources(new_coords, new_fluxes, new_ra_rates, new_dec_rates)  # type: ignore
+        return Sources(new_coords, new_fluxes, new_ra_rates, new_dec_rates)
 
     def __add__(self, other: "Sources") -> "Sources":
         return Sources.concat(self, other)
@@ -146,7 +147,7 @@ class Sources:
         Parameters
         ----------
         *sources_list : Sources
-            Two or more Sources objects to concatenate.
+            One or more Sources objects to concatenate.
 
         Returns
         -------
@@ -156,10 +157,10 @@ class Sources:
         if not sources_list:
             raise ValueError("Must provide at least one Sources object to concatenate.")
         return cls(
-            coords=concatenate([s.coords for s in sources_list]),
+            coords=np.concatenate([s.coords for s in sources_list]),  # type: ignore[arg-type]
             fluxes=np.concatenate([s.fluxes for s in sources_list]),
-            ra_rates=np.concatenate([s.ra_rates for s in sources_list]),  # type: ignore
-            dec_rates=np.concatenate([s.dec_rates for s in sources_list]),  # type: ignore
+            ra_rates=np.concatenate([s.ra_rates for s in sources_list]),
+            dec_rates=np.concatenate([s.dec_rates for s in sources_list]),
         )
 
     @classmethod
@@ -218,8 +219,8 @@ class Sources:
         return cls(
             coords=SkyCoord(ra=ra, dec=dec, unit=units),
             fluxes=fluxes,
-            ra_rates=ra_rates,  # type: ignore
-            dec_rates=dec_rates,  # type: ignore
+            ra_rates=ra_rates,
+            dec_rates=dec_rates,
         )
 
     def drop_nan_fluxes(self) -> "Sources":

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,201 @@
+import numpy as np
+import pytest
+
+from cabaret.image import _sample_trail, generate_star_image
+
+RNG = np.random.default_rng(42)
+
+
+# --- _sample_trail ---
+
+
+def test_sample_trail_shape():
+    result = _sample_trail(50.0, 60.0, 10.0, 5.0, 20, 0.0, RNG)
+    assert result.shape == (2, 20)
+
+
+def test_sample_trail_linear_no_jitter():
+    result = _sample_trail(0.0, 0.0, 10.0, 0.0, 5, 0.0, RNG)
+    assert np.allclose(result[0], [0.0, 2.5, 5.0, 7.5, 10.0])
+    assert np.allclose(result[1], 0.0)
+
+
+def test_sample_trail_end_position():
+    x0, y0, dx, dy = 3.0, 7.0, 12.0, -4.0
+    result = _sample_trail(x0, y0, dx, dy, 10, 0.0, RNG)
+    assert np.isclose(result[0, 0], x0)
+    assert np.isclose(result[1, 0], y0)
+    assert np.isclose(result[0, -1], x0 + dx)
+    assert np.isclose(result[1, -1], y0 + dy)
+
+
+def test_sample_trail_jitter_changes_output():
+    rng1 = np.random.default_rng(0)
+    rng2 = np.random.default_rng(0)
+    no_jitter = _sample_trail(50.0, 50.0, 10.0, 0.0, 20, 0.0, rng1)
+    with_jitter = _sample_trail(50.0, 50.0, 10.0, 0.0, 20, 1.0, rng2)
+    assert not np.allclose(no_jitter, with_jitter)
+
+
+# --- generate_star_image ---
+
+
+FRAME = (200, 200)
+
+
+def _noiseless_image(pos, fluxes, drift_pixels=None, n_trail_samples=50):
+    """Render stars with Poisson noise suppressed."""
+    rng = np.random.default_rng(0)
+
+    def _fixed_rng_poisson(flux):
+        return flux  # deterministic: no noise
+
+    # Monkey-patch not practical; use very large flux so Poisson ≈ mean
+    return generate_star_image(
+        pos=pos,
+        fluxes=fluxes,
+        FWHM=3.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=2400.0,
+        exp_time=1.0,
+        airmass=1.0,
+        drift_pixels=drift_pixels,
+        n_trail_samples=n_trail_samples,
+    )
+
+
+def test_zero_drift_regression():
+    """Zero-drift path produces same result as calling without drift_pixels."""
+    pos = np.array([[100.0], [100.0]])
+    fluxes = [1e6]
+    rng = np.random.default_rng(7)
+    kwargs = dict(
+        fluxes=fluxes,
+        FWHM=3.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=0.0,
+        exp_time=1.0,
+    )
+    img_no_drift = generate_star_image(pos=pos, **kwargs)
+    rng2 = np.random.default_rng(7)
+    img_zero_drift = generate_star_image(
+        pos=pos, drift_pixels=np.zeros((2, 1)), **{**kwargs, "rng": rng2}
+    )
+    assert np.allclose(img_no_drift, img_zero_drift)
+
+
+@pytest.mark.parametrize("dx,dy", [(0, 0), (10, 0), (0, 20), (10, 20)])
+def test_flux_conservation(dx, dy):
+    """Total flux in the image should approximately equal the input flux."""
+    flux = 1e7
+    pos = np.array([[100.0], [100.0]])
+    drift = np.array([[float(dx)], [float(dy)]])
+    rng = np.random.default_rng(1)
+    img = generate_star_image(
+        pos=pos,
+        fluxes=[flux],
+        FWHM=3.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=0.0,
+        exp_time=1.0,
+        drift_pixels=drift,
+        n_trail_samples=50,
+    )
+    # Allow 2% tolerance (Poisson noise on large flux)
+    assert abs(img.sum() - flux) / flux < 0.02
+
+
+def test_drifting_star_spans_expected_range():
+    """A star drifting 30px in x should illuminate pixels spread over ~30px."""
+    pos = np.array([[85.0], [100.0]])
+    drift = np.array([[30.0], [0.0]])
+    rng = np.random.default_rng(2)
+    img = generate_star_image(
+        pos=pos,
+        fluxes=[1e7],
+        FWHM=2.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=0.0,
+        exp_time=1.0,
+        drift_pixels=drift,
+        n_trail_samples=50,
+    )
+    # Find columns with significant flux
+    col_sums = img.sum(axis=0)
+    bright_cols = np.where(col_sums > col_sums.max() * 0.01)[0]
+    span = bright_cols.max() - bright_cols.min()
+    assert span >= 25, f"Expected trail span >= 25px, got {span}"
+
+
+def test_off_frame_trail_start_renders_end():
+    """Star starts off-frame left but drifts on-frame — should be rendered."""
+    pos = np.array([[-5.0], [100.0]])
+    drift = np.array([[30.0], [0.0]])
+    rng = np.random.default_rng(3)
+    img = generate_star_image(
+        pos=pos,
+        fluxes=[1e6],
+        FWHM=3.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=0.0,
+        exp_time=1.0,
+        drift_pixels=drift,
+        n_trail_samples=50,
+    )
+    assert img.sum() > 0, "Expected some flux on-frame from partially visible trail"
+
+
+def test_crossing_trail_both_endpoints_off_frame():
+    """Trail crossing the frame with both endpoints outside must produce flux.
+
+    Regression for the endpoint-only on_camera_mask that dropped such trails.
+    Start x=-20, end x=220 on a 200-wide frame: both off-frame, trail crosses fully.
+    """
+    pos = np.array([[-20.0], [100.0]])
+    drift = np.array([[240.0], [0.0]])
+    rng = np.random.default_rng(4)
+    img = generate_star_image(
+        pos=pos,
+        fluxes=[1e6],
+        FWHM=3.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=0.0,
+        exp_time=1.0,
+        drift_pixels=drift,
+        n_trail_samples=50,
+    )
+    assert img.sum() > 0, (
+        "Trail crossing the frame must render even when both endpoints are off-frame"
+    )
+
+
+def test_adaptive_sampling_short_trail_conserves_flux():
+    """Short trail (length < FWHM) reduces to 1 sample but must conserve flux."""
+    flux = 1e7
+    pos = np.array([[100.0], [100.0]])
+    drift = np.array([[1.0], [0.0]])  # 1 px drift with FWHM=3 → ceil(1/3*2)=1 sample
+    rng = np.random.default_rng(5)
+    img = generate_star_image(
+        pos=pos,
+        fluxes=[flux],
+        FWHM=3.0,
+        frame_size=FRAME,
+        rng=rng,
+        telescope_aperture=1.0,
+        site_elevation=0.0,
+        exp_time=1.0,
+        drift_pixels=drift,
+    )
+    assert abs(img.sum() - flux) / flux < 0.02

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -43,29 +43,6 @@ def test_sample_trail_jitter_changes_output():
 FRAME = (200, 200)
 
 
-def _noiseless_image(pos, fluxes, drift_pixels=None, n_trail_samples=50):
-    """Render stars with Poisson noise suppressed."""
-    rng = np.random.default_rng(0)
-
-    def _fixed_rng_poisson(flux):
-        return flux  # deterministic: no noise
-
-    # Monkey-patch not practical; use very large flux so Poisson ≈ mean
-    return generate_star_image(
-        pos=pos,
-        fluxes=fluxes,
-        FWHM=3.0,
-        frame_size=FRAME,
-        rng=rng,
-        telescope_aperture=1.0,
-        site_elevation=2400.0,
-        exp_time=1.0,
-        airmass=1.0,
-        drift_pixels=drift_pixels,
-        n_trail_samples=n_trail_samples,
-    )
-
-
 def test_zero_drift_regression():
     """Zero-drift path produces same result as calling without drift_pixels."""
     pos = np.array([[100.0], [100.0]])

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
@@ -71,3 +72,102 @@ def test_center_with_wrap():
 
     ra_center, _ = sources.center
     assert np.isclose(ra_center, 0.0)
+
+
+# --- rates ---
+
+
+def test_rates_default_to_zeros(example_sources):
+    assert example_sources.ra_rates.shape == (2,)
+    assert example_sources.dec_rates.shape == (2,)
+    assert np.all(example_sources.ra_rates == 0.0)
+    assert np.all(example_sources.dec_rates == 0.0)
+
+
+def test_rates_stored_correctly():
+    ra_rates = np.array([1.0, -0.5])
+    dec_rates = np.array([0.2, 0.0])
+    sources = Sources(
+        SkyCoord(COORDS, unit="deg"), FLUXES, ra_rates=ra_rates, dec_rates=dec_rates
+    )
+    assert np.allclose(sources.ra_rates, ra_rates)
+    assert np.allclose(sources.dec_rates, dec_rates)
+
+
+def test_rates_wrong_shape_raises():
+    with pytest.raises(ValueError):
+        Sources(SkyCoord(COORDS, unit="deg"), FLUXES, ra_rates=np.array([1.0]))
+    with pytest.raises(ValueError):
+        Sources(SkyCoord(COORDS, unit="deg"), FLUXES, dec_rates=np.array([1.0]))
+
+
+def test_getitem_slices_rates():
+    ra_rates = np.array([1.0, 2.0])
+    dec_rates = np.array([0.1, 0.2])
+    sources = Sources(
+        SkyCoord(COORDS, unit="deg"), FLUXES, ra_rates=ra_rates, dec_rates=dec_rates
+    )
+    sliced = sources[0]
+    assert sliced.ra_rates.shape == (1,)
+    assert np.isclose(sliced.ra_rates[0], 1.0)
+    assert np.isclose(sliced.dec_rates[0], 0.1)
+
+    masked = sources[np.array([False, True])]
+    assert np.isclose(masked.ra_rates[0], 2.0)
+
+
+def test_from_arrays_with_rates():
+    ra_rates = np.array([0.5, -0.3])
+    dec_rates = np.array([0.0, 0.1])
+    sources = Sources.from_arrays(
+        COORDS[:, 0], COORDS[:, 1], FLUXES, ra_rates=ra_rates, dec_rates=dec_rates
+    )
+    assert np.allclose(sources.ra_rates, ra_rates)
+    assert np.allclose(sources.dec_rates, dec_rates)
+
+
+def test_drop_nan_fluxes_preserves_rates():
+    fluxes = np.array([1.0, float("nan"), 3.0])
+    ra_rates = np.array([1.0, 2.0, 3.0])
+    coords = SkyCoord(ra=[10.0, 10.1, 10.2], dec=[41.0, 41.1, 41.2], unit="deg")
+    sources = Sources(coords, fluxes, ra_rates=ra_rates)
+    cleaned = sources.drop_nan_fluxes()
+    assert len(cleaned) == 2
+    assert np.allclose(cleaned.ra_rates, [1.0, 3.0])
+
+
+def test_concat_merges_rates():
+    ra_rates_a = np.array([1.0, 2.0])
+    sources_a = Sources(SkyCoord(COORDS, unit="deg"), FLUXES, ra_rates=ra_rates_a)
+    sources_b = Sources.get_test_sources()  # zero rates
+    merged = Sources.concat(sources_a, sources_b)
+    assert len(merged) == len(sources_a) + len(sources_b)
+    assert np.allclose(merged.ra_rates[:2], ra_rates_a)
+    assert np.all(merged.ra_rates[2:] == 0.0)
+
+
+def test_add_operator_delegates_to_concat(example_sources):
+    combined = example_sources + example_sources
+    assert len(combined) == 2 * len(example_sources)
+    assert np.allclose(combined.fluxes[:2], example_sources.fluxes)
+
+
+def test_rates_quantity_arcsec_per_hour():
+    rates = np.array([3600.0, -3600.0]) * u.arcsec / u.hour
+    sources = Sources(SkyCoord(COORDS, unit="deg"), FLUXES, ra_rates=rates)
+    assert np.allclose(sources.ra_rates, [1.0, -1.0])
+
+
+def test_rates_quantity_arcsec_per_second():
+    rates = np.array([1.0, 0.5]) * u.arcsec / u.s
+    sources = Sources(SkyCoord(COORDS, unit="deg"), FLUXES, ra_rates=rates)
+    assert np.allclose(sources.ra_rates, [1.0, 0.5])
+
+
+def test_rates_quantity_incompatible_unit_raises():
+    with pytest.raises(u.UnitConversionError):
+        Sources(
+            SkyCoord(COORDS, unit="deg"),
+            FLUXES,
+            ra_rates=np.array([1.0, 2.0]) * u.meter,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "cabaret"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
## Summary

Introduce per-source motion rates (ra_rates, dec_rates) to Sources and telescope tracking rate parameters to generate_image and Observatory. When tracking_ra_rate / tracking_dec_rate are set (e.g. to follow an asteroid), each star's pixel drift relative to the telescope is computed and rendered as a linear PSF trail via the new _sample_trail sampler. Adaptive sampling caps the number of Moffat evaluations based on trail length / FWHM. Also adds additional_sources injection, vmin/vmax overrides for plot_image, and an asteroid-tracking tutorial notebook.


- **Relative-motion trailing**: `Sources` now carries `ra_rates` / `dec_rates`
  (on-sky dα·cosδ/dt, accepts astropy Quantities or plain arcsec/s arrays). When
  `generate_image` / `Observatory.generate_image` receive non-zero
  `tracking_ra_rate` / `tracking_dec_rate`, each source's pixel displacement over
  the exposure is computed from its rate relative to the telescope slew rate.
  Moving sources (e.g. an asteroid being tracked) appear as point PSFs; background
  stars trail in the opposite direction.
- **Trail renderer** (`_sample_trail`): linear trail sampled adaptively at
  `max(1, ceil(trail_length / FWHM * 2))` points (capped at `n_trail_samples`).
  Optional `jitter_sigma_pixels` adds per-sample guiding jitter. A `trail_sampler`
  hook allows non-linear (e.g. ephemeris-spline) motion.
- **`additional_sources`**: inject arbitrary `Sources` on top of the Gaia star
  field at every level of the call stack.
- **`plot_image` `vmin`/`vmax`**: explicit colour-scale overrides alongside the
  existing ZScale auto-scaling.
- **Asteroid tracking notebook** (`docs/source/notebooks/asteroid_trailing.ipynb`):
  end-to-end example using JPL Horizons ephemerides for near-Earth asteroid 2024 MK
  across 5 consecutive exposures.

## Tests

- [x] `pytest tests/test_image.py` — new tests for `_sample_trail` (shape, linearity,
  start/end positions, jitter) and `generate_star_image` (zero-drift regression, flux
  conservation with/without drift, trail span, off-frame start, crossing trail, adaptive
  sampling)
- [x] `pytest tests/test_sources.py` — new rate tests: default zeros, storage, wrong
  shape raises, `__getitem__` slicing, `from_arrays`, `drop_nan_fluxes`, `concat`,
  `__add__`, unit conversion (arcsec/hour → arcsec/s, incompatible unit raises)
- [x] Run `asteroid_trailing.ipynb` end-to-end and verify asteroid appears centred and
  stars show trailing trails in the animation