### PR TITLE
Fix/scintillation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ name = "cabaret"
 readme = "README.md"
 repository = "https://github.com/ppp-one/cabaret"
 requires-python = ">=3.11"
-version = "0.5.3"
+version = "0.5.4"
 
 [project.optional-dependencies]
 docs = [

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -87,7 +87,7 @@ def scintillation_noise(
     t : float
         Exposure time in seconds.
     N_star : float
-        Number of stars.
+        Star flux (photons per second).
     h : float
         Altitude of the observatory in meters. Default is 2440 for Paranal Observatory.
     C : float
@@ -270,7 +270,7 @@ def generate_star_image(
         scint_noise = scintillation_noise(
             r=telescope_aperture / 2,
             t=exp_time,
-            N_star=flux,
+            N_star=flux / exp_time,
             h=site_elevation,
             C=1.56,
             airmass=airmass,

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "cabaret"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
* Clarified the docstring for the `scintillation_noise` function in `src/cabaret/image.py` to specify that `N_star` is the star flux (photons per second)
* Updated the call to `scintillation_noise` in `generate_star_image` so that `N_star` is now correctly passed as `flux / exp_time`