### PR TITLE
fix: base creation, add Gaia IDs, version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ name = "cabaret"
 readme = "README.md"
 repository = "https://github.com/ppp-one/cabaret"
 requires-python = ">=3.11"
-version = "0.5.4"
+version = "0.5.5"
 
 [project.optional-dependencies]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ name = "cabaret"
 readme = "README.md"
 repository = "https://github.com/ppp-one/cabaret"
 requires-python = ">=3.11"
-version = "0.5.3"
+version = "0.5.4"
 
 [project.optional-dependencies]
 docs = [

--- a/src/cabaret/camera.py
+++ b/src/cabaret/camera.py
@@ -173,9 +173,11 @@ class Camera:
         if rng is None:
             rng = np.random.default_rng()
 
-        base = np.ones((self.height, self.width)).astype(np.float64)
+        ones = np.ones((self.height, self.width)).astype(np.float64)
 
-        base += rng.poisson(base * self.dark_current * exp_time).astype(np.float64)
+        base = np.zeros_like(ones, dtype=np.float64)
+
+        base += rng.poisson(ones * self.dark_current * exp_time).astype(np.float64)
 
         base += rng.normal(0, self.read_noise, (self.height, self.width)).astype(
             np.float64

--- a/src/cabaret/image.py
+++ b/src/cabaret/image.py
@@ -87,7 +87,7 @@ def scintillation_noise(
     t : float
         Exposure time in seconds.
     N_star : float
-        Number of stars.
+        Star flux (photons per second).
     h : float
         Altitude of the observatory in meters. Default is 2440 for Paranal Observatory.
     C : float
@@ -270,7 +270,7 @@ def generate_star_image(
         scint_noise = scintillation_noise(
             r=telescope_aperture / 2,
             t=exp_time,
-            N_star=flux,
+            N_star=flux / exp_time,
             h=site_elevation,
             C=1.56,
             airmass=airmass,

--- a/src/cabaret/queries.py
+++ b/src/cabaret/queries.py
@@ -166,6 +166,7 @@ class GaiaTAPSource(Enum):
 _TAP_CONFIG: dict[GaiaTAPSource, dict] = {
     GaiaTAPSource.GAIA: {
         "from": "gaiadr3.gaia_source AS gaia",
+        "gaia_id": "gaia.source_id",
         "ra": "gaia.ra",
         "dec": "gaia.dec",
         "pmra": "gaia.pmra",
@@ -185,6 +186,7 @@ _TAP_CONFIG: dict[GaiaTAPSource, dict] = {
     },
     GaiaTAPSource.VIZIER: {
         "from": '"I/355/gaiadr3" AS g',
+        "gaia_id": 'g."Source"',
         "ra": "g.RA_ICRS",
         "dec": "g.DE_ICRS",
         "pmra": "g.pmRA",
@@ -203,6 +205,9 @@ _TAP_CONFIG: dict[GaiaTAPSource, dict] = {
 
 # Map Filters enum names to the per-source 2MASS column key in _TAP_CONFIG.
 _TMASS_COL_KEY = {"J": "j_col", "H": "h_col", "KS": "ks_col"}
+
+# Sentinel used for backends that cannot provide a Gaia source id (SQLite).
+_NO_GAIA_ID = -1
 
 
 class GaiaQuery:
@@ -297,9 +302,11 @@ class GaiaQuery:
         -------
         astropy.table.Table
             The raw Astropy Table returned by the TAP service, with columns
-            normalised to ``ra``, ``dec``, ``pmra``, ``pmdec``, and one magnitude
-            column per requested band named after ``filter_band.value``
-            (e.g. ``phot_g_mean_mag``, ``h_m``).
+            normalised to ``gaia_id``, ``ra``, ``dec``, ``pmra``, ``pmdec``, and
+            one magnitude column per requested band named after
+            ``filter_band.value`` (e.g. ``phot_g_mean_mag``, ``h_m``). The
+            SQLite backend has no Gaia identifier available and fills
+            ``gaia_id`` with ``-1``.
 
         Examples
         --------
@@ -511,13 +518,16 @@ class GaiaQuery:
         Returns
         -------
         Sources
-            A Sources instance containing the coordinates and fluxes of the retrieved
-            sources.
+            A Sources instance containing the coordinates, fluxes and Gaia source
+            ids of the retrieved sources.
 
 
         Notes
         -----
         Fluxes are always returned in photons/s/m² via :meth:`_mag_to_photons`.
+
+        ``gaia_ids`` holds the Gaia DR3 ``source_id`` when a TAP backend is used.
+        The SQLite backend carries no such identifier, so every id is ``-1``.
 
         Raises
         ------
@@ -560,6 +570,7 @@ class GaiaQuery:
             ra=table["ra"].value.data,  # type: ignore
             dec=table["dec"].value.data,  # type: ignore
             fluxes=fluxes,
+            gaia_ids=np.asarray(table["gaia_id"], dtype=np.int64),
         )
 
     @staticmethod
@@ -671,6 +682,7 @@ class GaiaQuery:
         cfg = _TAP_CONFIG[tap_source]
 
         select_cols = [
+            f"{cfg['gaia_id']} AS gaia_id",
             f"{cfg['ra']} AS ra",
             f"{cfg['dec']} AS dec",
             f"{cfg['pmra']} AS pmra",
@@ -794,7 +806,10 @@ class GaiaQuery:
                         )
                     selected_bands = requested_bands
 
+                # Local catalogs are not guaranteed to carry Gaia source ids,
+                # so they are reported as the -1 sentinel.
                 select_cols = [
+                    f"{_NO_GAIA_ID} AS gaia_id",
                     '"ra" AS ra',
                     '"dec" AS dec',
                     (
@@ -839,7 +854,7 @@ class GaiaQuery:
 
                 first_band = selected_bands[0]
 
-                output_names = ["ra", "dec", "pmra", "pmdec"] + [
+                output_names = ["gaia_id", "ra", "dec", "pmra", "pmdec"] + [
                     band.value for band in selected_bands
                 ]
                 if not selected_tables:

--- a/src/cabaret/sources.py
+++ b/src/cabaret/sources.py
@@ -2,8 +2,21 @@ from dataclasses import dataclass, field
 
 import numpy as np
 from astropy import units as u
-from astropy.coordinates import Longitude, SkyCoord
+from astropy.coordinates import Longitude, SkyCoord, concatenate
 from astropy.wcs import WCS
+
+NO_GAIA_ID = -1
+"""Sentinel id for sources that have no Gaia DR3 ``source_id``."""
+
+
+def _normalize_gaia_ids(gaia_ids: np.ndarray | list | None, n: int) -> np.ndarray:
+    """Convert gaia_ids to a plain int64 numpy array of shape (n,)."""
+    if gaia_ids is None:
+        return np.full(n, NO_GAIA_ID, dtype=np.int64)
+    gaia_ids = np.asarray(gaia_ids, dtype=np.int64)
+    if gaia_ids.shape != (n,):
+        raise ValueError(f"gaia_ids must have shape ({n},).")
+    return gaia_ids
 
 
 def _normalize_rates(
@@ -55,6 +68,10 @@ class Sources:
     """Dec motion rates, shape (n,) in arcsec/s. Accepts an astropy Quantity with
     angular velocity units or a plain array assumed to be in arcsec/s. Stored
     internally as arcsec/s. Positive values move north."""
+    gaia_ids: np.ndarray = field(init=False, repr=False)
+    """Gaia DR3 ``source_id`` per source, shape (n,) as int64. Sources with no
+    known Gaia counterpart — for instance everything coming from the SQLite
+    backend — carry ``NO_GAIA_ID`` (``-1``)."""
 
     def __init__(
         self,
@@ -62,6 +79,7 @@ class Sources:
         fluxes: np.ndarray,
         ra_rates: np.ndarray | u.Quantity | None = None,
         dec_rates: np.ndarray | u.Quantity | None = None,
+        gaia_ids: np.ndarray | list | None = None,
     ) -> None:
         if not isinstance(coords, SkyCoord):
             raise ValueError("coords must be an instance of SkyCoord.")
@@ -78,6 +96,7 @@ class Sources:
         n = coords.size
         self.ra_rates = _normalize_rates(ra_rates, n, "ra_rates")
         self.dec_rates = _normalize_rates(dec_rates, n, "dec_rates")
+        self.gaia_ids = _normalize_gaia_ids(gaia_ids, n)
 
     @property
     def ra(self) -> Longitude:
@@ -128,14 +147,18 @@ class Sources:
         new_fluxes = np.asarray(self.fluxes)[key]
         new_ra_rates = np.asarray(self.ra_rates)[key]
         new_dec_rates = np.asarray(self.dec_rates)[key]
+        new_gaia_ids = np.asarray(self.gaia_ids)[key]
         if np.isscalar(new_fluxes):
             new_fluxes = np.array([new_fluxes])
             new_ra_rates = np.array([new_ra_rates])
             new_dec_rates = np.array([new_dec_rates])
+            new_gaia_ids = np.array([new_gaia_ids])
 
         new_coords = self.coords[key]
 
-        return Sources(new_coords, new_fluxes, new_ra_rates, new_dec_rates)
+        return Sources(
+            new_coords, new_fluxes, new_ra_rates, new_dec_rates, new_gaia_ids
+        )
 
     def __add__(self, other: "Sources") -> "Sources":
         return Sources.concat(self, other)
@@ -157,10 +180,11 @@ class Sources:
         if not sources_list:
             raise ValueError("Must provide at least one Sources object to concatenate.")
         return cls(
-            coords=np.concatenate([s.coords for s in sources_list]),  # type: ignore[arg-type]
+            coords=concatenate([s.coords for s in sources_list]),  # type: ignore[arg-type]
             fluxes=np.concatenate([s.fluxes for s in sources_list]),
             ra_rates=np.concatenate([s.ra_rates for s in sources_list]),
             dec_rates=np.concatenate([s.dec_rates for s in sources_list]),
+            gaia_ids=np.concatenate([s.gaia_ids for s in sources_list]),
         )
 
     @classmethod
@@ -172,6 +196,7 @@ class Sources:
         units: str = "deg",
         ra_rates: np.ndarray | list | None = None,
         dec_rates: np.ndarray | list | None = None,
+        gaia_ids: np.ndarray | list | None = None,
     ) -> "Sources":
         """Create a Sources instance from separate RA and DEC arrays.
 
@@ -190,6 +215,9 @@ class Sources:
             RA motion rates in arcsec/s, shape (n,). Defaults to zeros.
         dec_rates : np.ndarray or list, optional
             Dec motion rates in arcsec/s, shape (n,). Defaults to zeros.
+        gaia_ids : np.ndarray or list, optional
+            Gaia DR3 ``source_id`` values, shape (n,). Defaults to ``-1`` for
+            every source.
 
         Returns
         -------
@@ -221,6 +249,7 @@ class Sources:
             fluxes=fluxes,
             ra_rates=ra_rates,
             dec_rates=dec_rates,
+            gaia_ids=gaia_ids,
         )
 
     def drop_nan_fluxes(self) -> "Sources":

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -45,6 +45,22 @@ def test_get_sources_gaia():
     assert sources is not None
 
 
+@pytest.mark.parametrize("tap_source", [GaiaTAPSource.VIZIER, GaiaTAPSource.GAIA])
+def test_get_sources_gaia_ids(tap_source):
+    """Both TAP backends resolve the same Gaia DR3 source ids."""
+    if not has_tap_source(tap_source):
+        pytest.skip(f"{tap_source.name} TAP unavailable")
+    center = SkyCoord(ra=10.68458, dec=41.269, unit="deg")
+    sources = GaiaQuery.get_sources(
+        center, radius=0.05, limit=3, timeout=60, tap_source=tap_source
+    )
+    assert sources.gaia_ids.dtype == np.int64
+    assert len(sources.gaia_ids) == len(sources)
+    assert np.all(sources.gaia_ids > 0)
+    # brightest-first ordering, so the same ids come back from either service
+    assert sources.gaia_ids[0] == 381261910408440576
+
+
 @skip_no_vizier
 def test_get_sources_timeout():
     center = SkyCoord(ra=10.68458, dec=41.26917, unit="deg")
@@ -339,6 +355,8 @@ def test_get_sources_sqlite_bounds(tmp_path):
 
     assert len(sources) == 2
     assert np.all(sources.fluxes > 0)
+    # SQLite catalogs carry no Gaia source id
+    assert np.all(sources.gaia_ids == -1)
 
 
 def test_query_sqlite_sharded_auto_detect_bounds(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "cabaret"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "cabaret"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
This pull request adds support for tracking Gaia DR3 source IDs throughout the source querying and handling pipeline. The `Sources` class now includes a `gaia_ids` field, and all relevant query functions and TAP backends have been updated to provide this identifier when available. For catalogs or backends that do not provide Gaia IDs (such as SQLite), a sentinel value of `-1` is used. The changes are fully tested to ensure correct propagation and handling of Gaia IDs.

**Enhancements to Gaia DR3 Source ID Handling:**

* Added a `gaia_ids` field to the `Sources` class, including normalization logic and support for concatenation, slicing, and construction from arrays. A sentinel value (`-1`) is used when no Gaia ID is available. (`src/cabaret/sources.py`) [[1]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084L5-R20) [[2]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084R71-R82) [[3]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084R99) [[4]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084R150-R161) [[5]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084L160-R187) [[6]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084R199) [[7]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084R218-R220) [[8]](diffhunk://#diff-21f2acae741860611511ab3a734f03e1839626b40bf274f8db57a685125fa084R252)

* Updated Gaia TAP and Vizier query configurations and logic to always provide a `gaia_id` column in results, and to use the sentinel value for backends (like SQLite) that do not provide Gaia IDs. (`src/cabaret/queries.py`) [[1]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758R169) [[2]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758R189) [[3]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758R209-R211) [[4]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758R685) [[5]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758R809-R812) [[6]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758L842-R857)

* Modified the documentation and return values of `GaiaQuery.get_sources` and related methods to reflect the presence and meaning of the `gaia_ids` field. (`src/cabaret/queries.py`) [[1]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758L300-R309) [[2]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758L514-R531) [[3]](diffhunk://#diff-428729f392ef9854da525e69ecaca9031098a4e1a212e9c69e0d1a763952d758R573)

**Testing and Validation:**

* Added and updated tests to verify that Gaia IDs are correctly propagated for TAP backends and that the sentinel value is used for SQLite catalogs. (`tests/test_queries.py`) [[1]](diffhunk://#diff-966c2533398c39c686c721eb85e31ff94bc92f5b02f9c5fe1c7d525651028e73R48-R63) [[2]](diffhunk://#diff-966c2533398c39c686c721eb85e31ff94bc92f5b02f9c5fe1c7d525651028e73R358-R359)

**Miscellaneous Improvements:**

* Updated the project version to `0.5.5` in `pyproject.toml`.
* Clarified parameter documentation in `scintillation_noise` and fixed a flux calculation bug in `generate_star_image`. (`src/cabaret/image.py`) [[1]](diffhunk://#diff-3519190320f317997a4c54da9e644b8bbc22f6217ec1a2a742a07f4dbda07b79L90-R90) [[2]](diffhunk://#diff-3519190320f317997a4c54da9e644b8bbc22f6217ec1a2a742a07f4dbda07b79L273-R273)
* Minor refactor in base image creation logic for clarity. (`src/cabaret/camera.py`)